### PR TITLE
feat(scan): add DeepSeek-V4 as a frontier --model provider

### DIFF
--- a/miesc/cli/commands/scan.py
+++ b/miesc/cli/commands/scan.py
@@ -8,6 +8,7 @@ License: AGPL-3.0
 """
 
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -90,6 +91,8 @@ if RICH_AVAILABLE:
             "gpt-4o",
             "gpt-4.1",
             "gpt-5",
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
             "ollama",
             "qwen32b",
             "qwen14b",
@@ -395,12 +398,26 @@ def scan(
                     "gpt-4o": ("openai", "gpt-4o"),
                     "gpt-4.1": ("openai", "gpt-4.1"),
                     "gpt-5": ("openai", "gpt-5"),
+                    # DeepSeek V4 is OpenAI-compatible; routed via the OpenAI
+                    # client pointed at the DeepSeek endpoint (see env setup below).
+                    "deepseek-v4-pro": ("openai", "deepseek-v4-pro"),
+                    "deepseek-v4-flash": ("openai", "deepseek-v4-flash"),
                     "ollama": ("ollama", "qwen2.5-coder:32b"),
                     "qwen32b": ("ollama", "qwen2.5-coder:32b"),
                     "qwen14b": ("ollama", "qwen2.5-coder:14b"),
                     "codellama": ("ollama", "codellama:13b"),
                 }
                 provider, model_id = provider_map.get(frontier_model.lower(), ("auto", None))
+                # DeepSeek exposes an OpenAI-compatible API. Point the OpenAI
+                # client at the DeepSeek endpoint using DEEPSEEK_API_KEY so the
+                # existing openai code path sends the deepseek-v4 model name.
+                if frontier_model.lower().startswith("deepseek") and os.environ.get(
+                    "DEEPSEEK_API_KEY"
+                ):
+                    os.environ["OPENAI_API_KEY"] = os.environ["DEEPSEEK_API_KEY"]
+                    os.environ["OPENAI_BASE_URL"] = os.environ.get(
+                        "DEEPSEEK_BASE_URL", "https://api.deepseek.com"
+                    )
                 adapter = FrontierLLMAdapter(provider=provider)
 
                 if adapter.is_available() == ToolStatus.AVAILABLE:
@@ -617,12 +634,23 @@ def scan(
                 "gpt-4o": ("openai", "gpt-4o"),
                 "gpt-4.1": ("openai", "gpt-4.1"),
                 "gpt-5": ("openai", "gpt-5"),
+                "deepseek-v4-pro": ("openai", "deepseek-v4-pro"),
+                "deepseek-v4-flash": ("openai", "deepseek-v4-flash"),
                 "ollama": ("ollama", "qwen2.5-coder:32b"),
                 "qwen32b": ("ollama", "qwen2.5-coder:32b"),
                 "qwen14b": ("ollama", "qwen2.5-coder:14b"),
                 "codellama": ("ollama", "codellama:13b"),
             }
             provider, model_id = provider_map.get(frontier_model.lower(), ("auto", None))
+            # DeepSeek V4 is OpenAI-compatible: point the OpenAI client at the
+            # DeepSeek endpoint using DEEPSEEK_API_KEY.
+            if frontier_model.lower().startswith("deepseek") and os.environ.get(
+                "DEEPSEEK_API_KEY"
+            ):
+                os.environ["OPENAI_API_KEY"] = os.environ["DEEPSEEK_API_KEY"]
+                os.environ["OPENAI_BASE_URL"] = os.environ.get(
+                    "DEEPSEEK_BASE_URL", "https://api.deepseek.com"
+                )
             adapter = FrontierLLMAdapter(provider=provider)
 
             if (

--- a/src/adapters/frontier_llm_adapter.py
+++ b/src/adapters/frontier_llm_adapter.py
@@ -652,9 +652,12 @@ Respond with a JSON array."""
                 import openai
 
                 client = openai.OpenAI()
+                _dp_model = kwargs.get("model", "gpt-4o")
                 resp = client.chat.completions.create(
-                    model=kwargs.get("model", "gpt-4o"),
-                    max_tokens=4096,
+                    model=_dp_model,
+                    # Reasoning models (DeepSeek V4) need a large budget: reasoning
+                    # runs before visible output, so 4096 yields empty content.
+                    max_tokens=32768 if _dp_model.startswith("deepseek") else 4096,
                     messages=[
                         {"role": "system", "content": AUDIT_SYSTEM_PROMPT},
                         {"role": "user", "content": deep_prompt},
@@ -1239,6 +1242,11 @@ Respond with a JSON array."""
         if model.startswith(("gpt-5", "o1", "o3", "o4")):
             token_param["max_completion_tokens"] = 32768
             extra["reasoning_effort"] = "low"
+        elif model.startswith("deepseek"):
+            # DeepSeek V4 is a reasoning model: hidden reasoning consumes part of
+            # the budget before any visible output, so 8192 left content empty
+            # (0 chars). Give a large budget so reasoning + the JSON both fit.
+            token_param["max_tokens"] = 32768
         else:
             token_param["max_tokens"] = 8192
             # o-series/gpt-5 reject a custom temperature; only set it elsewhere.
@@ -1407,6 +1415,11 @@ Respond with a JSON array."""
         if model.startswith(("gpt-5", "o1", "o3", "o4")):
             token_param["max_completion_tokens"] = 32768
             extra["reasoning_effort"] = "low"
+        elif model.startswith("deepseek"):
+            # DeepSeek V4 is a reasoning model: hidden reasoning consumes part of
+            # the budget before any visible output, so 8192 left content empty
+            # (0 chars). Give a large budget so reasoning + the JSON both fit.
+            token_param["max_tokens"] = 32768
         else:
             token_param["max_tokens"] = 8192
             # o-series/gpt-5 reject a custom temperature; only set it elsewhere.


### PR DESCRIPTION
## Summary

DeepSeek exposes an OpenAI-compatible API, but MIESC could not use it as a
detector: the `scan --model` enum omitted DeepSeek and nothing routed the
OpenAI client to the DeepSeek endpoint. This adds DeepSeek-V4
(`deepseek-v4-pro` / `deepseek-v4-flash`) as a first-class `--model` provider,
on par with Claude and GPT.

## Changes

- **`miesc/cli/commands/scan.py`**: add `deepseek-v4-pro` / `deepseek-v4-flash`
  to `--model` (both frontier blocks) and point the OpenAI client at
  `api.deepseek.com` via `DEEPSEEK_API_KEY` (optional `DEEPSEEK_BASE_URL`) when a
  deepseek model is selected.
- **`src/adapters/frontier_llm_adapter.py`**: DeepSeek V4 is a reasoning model.
  Its hidden reasoning consumed the `max_tokens=8192/4096` budget before emitting
  output, so `content` came back empty ("0 chars"). Give it the same large budget
  already used for GPT-5 / o-series (`32768`) in the main and deep passes.

## Usage

```bash
DEEPSEEK_API_KEY=... miesc scan Contract.sol --model deepseek-v4-pro --deep
```

## Testing

Verified end-to-end on a 4-contract benchmark corpus (29 documented
vulnerabilities). DeepSeek-V4-flash `--deep` reaches ~55% type-aware recall /
90% coverage — between local qwen-14b (45%) and the top frontier tier
(GPT-4o / Sonnet / Opus, 72%). Before this change the same run produced 0 LLM
findings due to the empty-content bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
