### PR TITLE
fix(adapters): define temperature in _analyze_openai (F821 latent NameError)

### DIFF
--- a/src/adapters/frontier_llm_adapter.py
+++ b/src/adapters/frontier_llm_adapter.py
@@ -1399,6 +1399,7 @@ Respond with a JSON array."""
         client: Any = openai.OpenAI()
         rag_context = kwargs.pop("rag_context", "")
         model = kwargs.get("model", "gpt-4o")
+        temperature = kwargs.get("temperature", 0.2)
         self._model = model
 
         user_prompt = self._build_user_prompt(source_code, rag_context)


### PR DESCRIPTION
## Summary

Fixes a latent `NameError` (ruff **F821 undefined name `temperature`**) in
`FrontierLLMAdapter._analyze_openai`.

## Root cause

`_analyze_openai(self, source_code, **kwargs)` does not accept or define a
`temperature` variable, yet the non-reasoning branch does:

```python
else:
    token_param["max_tokens"] = 8192
    extra["temperature"] = temperature   # <-- undefined
```

Any call on the standard OpenAI path (`--model gpt-4o` / `gpt-4.1`, not the
gpt-5/o-series reasoning branch) would raise `NameError: name 'temperature' is
not defined`. The sibling conversation methods (`_analyze_anthropic` and the
tool-conversation helpers) already take `temperature: float = 0.2`, so the
non-reasoning path here was simply missing that binding.

## Fix

Define `temperature` from `kwargs` with the same `0.2` default the sibling
methods use:

```python
model = kwargs.get("model", "gpt-4o")
temperature = kwargs.get("temperature", 0.2)
```

One line, no behavior change other than making the existing code reachable
without crashing.

## Verification

```
# before
$ ruff check src/adapters/frontier_llm_adapter.py --select F821
  frontier_llm_adapter.py:1426: F821 Undefined name `temperature`   (1 error)
# after
$ ruff check src/adapters/frontier_llm_adapter.py --select F821
  All checks passed!
```

Found while reviewing CI on #70. Pre-existing on `main`; unrelated to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
