### PR TITLE
feat(adapters): deterministic LLM calls (temperature 0 + fixed seed)

### DIFF
--- a/src/adapters/frontier_llm_adapter.py
+++ b/src/adapters/frontier_llm_adapter.py
@@ -1247,10 +1247,14 @@ Respond with a JSON array."""
             # the budget before any visible output, so 8192 left content empty
             # (0 chars). Give a large budget so reasoning + the JSON both fit.
             token_param["max_tokens"] = 32768
+            # Determinism: temperature 0 + fixed seed so repeated runs match.
+            extra["temperature"] = 0.0
+            extra["seed"] = int(os.environ.get("MIESC_LLM_SEED", "42"))
         else:
             token_param["max_tokens"] = 8192
-            # o-series/gpt-5 reject a custom temperature; only set it elsewhere.
-            extra["temperature"] = temperature
+            # Determinism: temperature 0 + fixed seed so repeated runs match.
+            extra["temperature"] = 0.0
+            extra["seed"] = int(os.environ.get("MIESC_LLM_SEED", "42"))
 
         logger.info(
             "FrontierLLM: Starting tool-use conversation with %s "
@@ -1420,10 +1424,14 @@ Respond with a JSON array."""
             # the budget before any visible output, so 8192 left content empty
             # (0 chars). Give a large budget so reasoning + the JSON both fit.
             token_param["max_tokens"] = 32768
+            # Determinism: temperature 0 + fixed seed so repeated runs match.
+            extra["temperature"] = 0.0
+            extra["seed"] = int(os.environ.get("MIESC_LLM_SEED", "42"))
         else:
             token_param["max_tokens"] = 8192
-            # o-series/gpt-5 reject a custom temperature; only set it elsewhere.
-            extra["temperature"] = temperature
+            # Determinism: temperature 0 + fixed seed so repeated runs match.
+            extra["temperature"] = 0.0
+            extra["seed"] = int(os.environ.get("MIESC_LLM_SEED", "42"))
 
         response = client.chat.completions.create(
             model=model,
@@ -1544,7 +1552,11 @@ Respond with a JSON array."""
                     {"role": "user", "content": user_prompt},
                 ],
                 "stream": False,
-                "options": {"temperature": 0.1, "num_predict": 4096},
+                "options": {
+                    "temperature": 0,
+                    "seed": int(os.environ.get("MIESC_LLM_SEED", "42")),
+                    "num_predict": 4096,
+                },
             }
         ).encode()
 


### PR DESCRIPTION
## Summary

LLM detection calls ran at temperature 0.1–0.2 with no seed, so repeated runs of
the same scan varied by a finding or two. This sets **temperature=0** and a
**fixed seed** (`MIESC_LLM_SEED`, default 42) across the OpenAI, DeepSeek and
Ollama code paths, making runs reproducible.

## Changes

`src/adapters/frontier_llm_adapter.py`:
- OpenAI / DeepSeek chat-completion calls: `temperature=0.0`, `seed=MIESC_LLM_SEED`.
- Ollama options: `temperature=0`, `seed=MIESC_LLM_SEED`.

## Measured effect (same scan run twice on `FlashLoanVault.sol`)

| Model | Raw findings | Detection metric | Determinism |
|---|---|---|---|
| qwen2.5-coder:14b (Ollama, local) | 12 = 12, **identical** | 2/10 = 2/10 | ✅ bit-for-bit |
| deepseek-v4-flash (reasoning, API) | 36 vs 31 | 4/10 = 4/10 | metric stable, raw varies |

Local models become fully reproducible run-to-run. Frontier **reasoning** models
keep a stable detection result, but their raw output still varies provider-side
(the hidden reasoning is not seed-controllable) — expected and documented.

## Also fixes F821 (supersedes #71)

The non-reasoning branch of `_analyze_openai` referenced an undefined `temperature`
variable (`F821`, a latent `NameError`). This PR assigns a constant `0.0` there,
resolving it. #71 (the standalone F821 fix) becomes redundant and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
