### PR TITLE
fix(orchestrator): collapse exact-duplicate findings preserving tool provenance (#69)

### DIFF
--- a/miesc/core/ml_orchestrator.py
+++ b/miesc/core/ml_orchestrator.py
@@ -397,6 +397,19 @@ class MLOrchestrator:
         if progress_callback:
             progress_callback("aggregation", "Aggregating results", 0.8)
 
+        # Collapse exact-duplicate findings (issue #69): the same vulnerability
+        # reported by multiple tools at the same location is pure noise in the
+        # headline count. Provenance is preserved in each survivor's "tools" list;
+        # findings that differ in any identifying field are never collapsed.
+        ml_filtered_findings, duplicates_collapsed = self._collapse_exact_duplicates(
+            ml_filtered_findings
+        )
+        if duplicates_collapsed:
+            logger.info(
+                "Collapsed %d exact-duplicate findings (provenance preserved)",
+                duplicates_collapsed,
+            )
+
         # Calculate severity distribution
         severity_dist = self._calculate_severity_distribution(ml_filtered_findings)
 
@@ -435,6 +448,53 @@ class MLOrchestrator:
             ml_processing_time_ms=ml_processing_time,
             timestamp=datetime.now(),
         )
+
+    @staticmethod
+    def _duplicate_key(f: Dict[str, Any]) -> tuple:
+        """Identity of a finding, independent of the reporting tool.
+
+        Two findings share this key only if they are the *same* vulnerability at
+        the *same* location, i.e. they differ solely in which tool reported them.
+        """
+        loc = f.get("location", {}) or {}
+        return (
+            loc.get("file"),
+            loc.get("line"),
+            f.get("swc"),
+            f.get("type"),
+            f.get("check"),
+            (f.get("title") or "").strip().lower(),
+            (f.get("severity") or "").strip().lower(),
+        )
+
+    def _collapse_exact_duplicates(
+        self, findings: List[Dict[str, Any]]
+    ) -> "tuple[List[Dict[str, Any]], int]":
+        """Collapse findings that are identical except for the reporting tool.
+
+        Multiple tools frequently report the same vulnerability at the same line
+        (e.g. four SWC-107 findings). These are noise in the reported count: keep
+        one representative per identity and record every contributing tool in its
+        ``tools`` list. Findings that differ in any identifying field are preserved
+        untouched, so recall is not affected. Returns (deduped, num_collapsed).
+        """
+        grouped: Dict[tuple, Dict[str, Any]] = {}
+        order: List[tuple] = []
+        collapsed = 0
+        for f in findings:
+            k = self._duplicate_key(f)
+            if k in grouped:
+                rep = grouped[k]
+                tool = f.get("tool")
+                if tool and tool not in rep["tools"]:
+                    rep["tools"].append(tool)
+                collapsed += 1
+            else:
+                rep = dict(f)
+                rep["tools"] = [f["tool"]] if f.get("tool") else []
+                grouped[k] = rep
+                order.append(k)
+        return [grouped[k] for k in order], collapsed
 
     def _is_same_location(self, f1: Dict[str, Any], f2: Dict[str, Any]) -> bool:
         """Verifica si dos hallazgos están en la misma ubicación."""

--- a/tests/test_orchestrator_fp_recall_safety.py
+++ b/tests/test_orchestrator_fp_recall_safety.py
@@ -9,6 +9,7 @@ filter drop a true positive, recall silently regresses; these tests guard that.
 
 import unittest
 
+from miesc.core.ml_orchestrator import MLOrchestrator
 from miesc.ml.fp_filter import FalsePositiveFilter
 
 # A modern-Solidity contract: the solc-version pragma warning is a textbook
@@ -85,6 +86,61 @@ class TestOrchestratorFPRecallSafety(unittest.TestCase):
         self.assertFalse(
             fr.is_likely_fp, "recall regression: real overflow dropped by SafeMath heuristic"
         )
+
+
+class TestExactDuplicateCollapse(unittest.TestCase):
+    """Issue #69(b): findings that are identical except for the reporting tool
+    collapse to a single entry (with provenance preserved), while findings that
+    differ in any identifying field are never collapsed."""
+
+    def setUp(self):
+        self.orch = MLOrchestrator(ml_enabled=False)
+
+    def _f(self, swc, line, tool, file="C.sol", severity="high", title=None):
+        return {
+            "swc": swc,
+            "type": swc,
+            "check": swc,
+            "title": title or swc,
+            "severity": severity,
+            "tool": tool,
+            "location": {"file": file, "line": line},
+        }
+
+    def test_identical_findings_from_different_tools_collapse(self):
+        findings = [
+            self._f("SWC-107", 20, "slither"),
+            self._f("SWC-107", 20, "mythril"),
+            self._f("SWC-107", 20, "aderyn"),
+            self._f("SWC-107", 20, "gptscan"),
+        ]
+        deduped, collapsed = self.orch._collapse_exact_duplicates(findings)
+        self.assertEqual(len(deduped), 1)
+        self.assertEqual(collapsed, 3)
+        self.assertEqual(set(deduped[0]["tools"]), {"slither", "mythril", "aderyn", "gptscan"})
+
+    def test_distinct_findings_are_preserved(self):
+        findings = [
+            self._f("SWC-107", 20, "slither"),  # reentrancy @ L20
+            self._f("SWC-107", 42, "slither"),  # reentrancy @ L42 (different line)
+            self._f("SWC-101", 20, "slither"),  # overflow @ L20 (different swc)
+            self._f("SWC-107", 20, "mythril"),  # exact dup of the first
+        ]
+        deduped, collapsed = self.orch._collapse_exact_duplicates(findings)
+        self.assertEqual(len(deduped), 3, "distinct findings must be preserved")
+        self.assertEqual(collapsed, 1, "only the exact duplicate is collapsed")
+
+    def test_empty_input(self):
+        deduped, collapsed = self.orch._collapse_exact_duplicates([])
+        self.assertEqual(deduped, [])
+        self.assertEqual(collapsed, 0)
+
+    def test_original_findings_are_not_mutated(self):
+        f1 = self._f("SWC-107", 20, "slither")
+        f2 = self._f("SWC-107", 20, "mythril")
+        self.orch._collapse_exact_duplicates([f1, f2])
+        self.assertNotIn("tools", f1, "input findings must not be mutated")
+        self.assertNotIn("tools", f2, "input findings must not be mutated")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ports the issue #69 exact-duplicate collapse into the **shipped** `miesc.core` orchestrator. The harness fix lived only on the `src.core` reproduction layout, so the bug was unfixed for users.

## What
Identical findings reported by multiple tools (same file, line, SWC/type, title, severity) collapse into one entry whose `tools` list records every reporting tool. Distinct findings are never merged; input findings are not mutated. Runs after the `fp_strictness` stage, before severity distribution — so both the reported count and severity histogram reflect the deduped set.

## Tests
`TestExactDuplicateCollapse`: identical-across-tools collapse, distinct-preservation, empty input, no-mutation. 7/7 in the file pass; ruff + black clean.

Closes the reporting-count half of #69 (part b); part a (`fp_strictness` filter) is already on main.