### PR TITLE
fix(config): resolve packaged config from the installed package

### DIFF
--- a/miesc/core/config_loader.py
+++ b/miesc/core/config_loader.py
@@ -1,6 +1,7 @@
 """
 MIESC Configuration Loader
-Carga y gestiona la configuración centralizada desde config/miesc.yaml
+Carga y gestiona la configuración centralizada desde el archivo empaquetado
+miesc/data/config/miesc.yaml (con overrides opcionales por env MIESC_CONFIG o cwd).
 """
 
 import os
@@ -48,10 +49,15 @@ class MIESCConfig:
         """Encuentra el archivo de configuración."""
         # Buscar en orden de prioridad
         env_config = os.environ.get("MIESC_CONFIG", "")
+        # Single packaged source of truth: miesc/data/config/miesc.yaml. Resolved
+        # relative to the package (parent.parent), so it works both from a source
+        # checkout and from an installed wheel (site-packages/miesc/data/config/...).
+        # The cwd/env paths above it allow optional per-project or per-user overrides.
+        packaged = Path(__file__).parent.parent / "data" / "config" / "miesc.yaml"
         search_paths = [
             Path.cwd() / "config" / "miesc.yaml",
             Path.cwd() / "miesc.yaml",
-            Path(__file__).parent.parent.parent / "config" / "miesc.yaml",
+            packaged,
             Path.home() / ".miesc" / "config.yaml",
         ]
 
@@ -64,7 +70,7 @@ class MIESCConfig:
                 return path
 
         # Retornar path default aunque no exista
-        return Path(__file__).parent.parent.parent / "config" / "miesc.yaml"
+        return packaged
 
     def _load_config(self) -> None:
         """Carga la configuración desde el archivo YAML."""

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -551,3 +551,40 @@ class TestConfigLoaderFallbacks:
         cfg._config = {"compliance": {"enabled": False}}
         assert cfg.get_compliance_frameworks() == []
         self._reset()
+
+
+class TestConfigFileDiscovery:
+    """The packaged config must be discoverable from an installed wheel, where
+    there is no ``./config/miesc.yaml`` beside the CWD. Regression: the loader
+    used to look under ``<install-root>/config/`` (which is never shipped) and
+    silently fell back to hardcoded defaults."""
+
+    @pytest.fixture
+    def reset_singleton(self):
+        MIESCConfig._instance = None
+        yield
+        MIESCConfig._instance = None
+
+    def _packaged_path(self) -> Path:
+        import miesc.core.config_loader as cl
+
+        return Path(cl.__file__).parent.parent / "data" / "config" / "miesc.yaml"
+
+    def test_packaged_config_ships_inside_package(self):
+        assert (
+            self._packaged_path().is_file()
+        ), "miesc/data/config/miesc.yaml must ship inside the miesc package"
+
+    def test_wheel_run_resolves_packaged_config_not_defaults(
+        self, reset_singleton, tmp_path, monkeypatch
+    ):
+        # Simulate an installed-wheel run: cwd has no ./config or ./miesc.yaml,
+        # and no MIESC_CONFIG override. The loader must resolve to the packaged
+        # config, not to the never-shipped <root>/config/ path or defaults.
+        monkeypatch.delenv("MIESC_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        packaged = self._packaged_path()
+        cfg = MIESCConfig()
+        assert cfg._find_config_file() == packaged
+        # And the loaded config is the real packaged file, not hardcoded defaults.
+        assert cfg.version == yaml.safe_load(packaged.read_text())["version"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3461,20 +3461,27 @@ class TestConfigLoaderCoverage:
             self._reset_singleton()
 
     def test_default_config_when_no_file(self, tmp_path, monkeypatch):
-        """Test default config when no file exists (lines 64, 74, 78)."""
+        """With no cwd/env override, the loader resolves to the PACKAGED config
+        (miesc/data/config/miesc.yaml), not a hardcoded version. Previously this
+        asserted a hardcoded "5.1.2" that only matched the stale repo-root config;
+        the loader now points at the packaged file, so compare dynamically."""
         import os
+        from pathlib import Path
 
+        import yaml
+
+        import miesc.core.config_loader as cl
         from miesc.core.config_loader import MIESCConfig
 
         self._reset_singleton()
 
-        # Mock Path.cwd() to return a temp dir with no config
+        # Mock Path.cwd() to a temp dir with no ./config, and drop the env override.
         monkeypatch.setattr("pathlib.Path.cwd", lambda: tmp_path)
         os.environ.pop("MIESC_CONFIG", None)
 
         config = MIESCConfig()
-        # Should get default config
-        assert config.version == "5.1.2"
+        packaged = Path(cl.__file__).parent.parent / "data" / "config" / "miesc.yaml"
+        assert config.version == yaml.safe_load(packaged.read_text())["version"]
         self._reset_singleton()
 
     def test_get_config_function(self):


### PR DESCRIPTION
## Bug
`config_loader._find_config_file()` looked for `<install-root>/config/miesc.yaml` (`Path(__file__).parent.parent.parent / "config"`). That path is **never shipped** — the wheel packages `miesc/data/config/*.yaml`, not a top-level `config/`. So an installed `miesc` found no config file and silently fell back to hardcoded defaults, ignoring its own packaged `miesc.yaml`. 8+ modules consume `get_config()`, so this affected the real product.

## Fix
Point the canonical source at `miesc/data/config/miesc.yaml` resolved as `Path(__file__).parent.parent / "data" / "config"` — correct from both a source checkout **and** an installed wheel (`site-packages/miesc/data/config/...`). `cwd`/`MIESC_CONFIG` overrides preserved.

## Tests
`TestConfigFileDiscovery`: (1) the packaged config ships inside the package; (2) a simulated wheel run (cwd without `./config`, no env override) resolves to the packaged file and loads its version, not defaults. 43/43 config tests pass; ruff + black clean.

**Not auto-merged** — core module used broadly; merge after CI is green and main is calm (concurrent lane activity in flight). Follow-up (separate): the stale top-level `config/miesc.yaml` (v5.1.2) still shadows in dev via the cwd path — sync or remove it.