### PR TITLE
docs(config): point remaining code refs at the packaged config path

### DIFF
--- a/miesc/adapters/gptlens_adapter.py
+++ b/miesc/adapters/gptlens_adapter.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 # Ollama URL resolved at runtime via get_ollama_host()
-# Supports OLLAMA_HOST env var and config/miesc.yaml
+# Supports OLLAMA_HOST env var and the packaged miesc/data/config/miesc.yaml
 
 # Default models for each role
 DEFAULT_AUDITOR_MODEL = "deepseek-coder"

--- a/miesc/adapters/llamaaudit_adapter.py
+++ b/miesc/adapters/llamaaudit_adapter.py
@@ -311,7 +311,7 @@ OUTPUT FORMAT - Respond with ONLY valid JSON:
 Respond with ONLY the JSON object. No explanations outside JSON."""
 
     # Ollama URLs resolved at runtime via get_ollama_host()
-    # Supports OLLAMA_HOST env var and config/miesc.yaml
+    # Supports OLLAMA_HOST env var and the packaged miesc/data/config/miesc.yaml
 
     def __init__(self) -> None:
         super().__init__()

--- a/miesc/cli/utils.py
+++ b/miesc/cli/utils.py
@@ -240,7 +240,7 @@ def load_config() -> Dict[str, Any]:
 
 
 def load_profiles() -> Dict[str, Any]:
-    """Load analysis profiles from config/profiles.yaml."""
+    """Load analysis profiles from the packaged miesc/data/config/profiles.yaml."""
     profiles_path = get_data_path("config", "profiles.yaml")
     if profiles_path.exists() and YAML_AVAILABLE:
         with open(profiles_path) as f:


### PR DESCRIPTION
Follow-up to #77. Three comments/docstrings still named the removed repo-root `config/miesc.yaml` / `config/profiles.yaml` (gptlens/llamaaudit adapter comments + `load_profiles` docstring). Repointed to the packaged `miesc/data/config/*.yaml`. **Comment/docstring only — zero behavior change.** Completes the config path-reference consistency after the single-source removal.