### PR TITLE
fix(docker): pin base images by digest (MED-005, CWE-1104) — closes security backlog 8/8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,9 @@
 # ============================================================
 # Stage 1a: aderyn-downloader (runs in parallel with foundry-builder)
 # ============================================================
-FROM python:3.12-slim-bookworm AS aderyn-downloader
+# Base image pinned by digest (MED-005): Dependabot's docker ecosystem keeps the
+# digest current, so security patches still flow while builds stay reproducible.
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS aderyn-downloader
 ARG TARGETARCH
 ARG ADERYN_VERSION=0.6.8
 
@@ -50,7 +52,7 @@ RUN set -eux; \
 # ============================================================
 # Stage 1b: foundry-builder (runs in parallel with aderyn-downloader)
 # ============================================================
-FROM python:3.12-slim-bookworm AS foundry-builder
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS foundry-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
@@ -70,7 +72,7 @@ RUN foundryup
 # ============================================================
 # Stage 2: Runtime - Create lean production image
 # ============================================================
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b
 
 LABEL maintainer="Fernando Boiero <fboiero@frvm.utn.edu.ar>"
 ARG MIESC_VERSION=6.0.0

--- a/docker/Dockerfile.x86
+++ b/docker/Dockerfile.x86
@@ -12,7 +12,8 @@
 # Force x86_64 architecture for all stages
 # Using Python 3.10 for Manticore compatibility (pysha3 incompatible with 3.11+)
 # Security Note: Python 3.10 EOL is October 2026 - migrate to 3.12 when Manticore supports it
-FROM --platform=linux/amd64 python:3.10-slim-bookworm AS builder
+# Base image pinned by digest (MED-005); Dependabot's docker ecosystem keeps it current.
+FROM --platform=linux/amd64 python:3.10-slim-bookworm@sha256:9643927a6fc74bd81b0f1bbb5cce3cb4a491f46b4c5dbee770f28e575f180015 AS builder
 
 LABEL maintainer="Fernando Boiero <fboiero@frvm.utn.edu.ar>"
 LABEL version="6.0.0"
@@ -53,7 +54,7 @@ RUN cargo install aderyn
 
 # Stage 2: Runtime - x86_64 production image
 # Using Python 3.10 for Manticore compatibility (pysha3 incompatible with 3.11+)
-FROM --platform=linux/amd64 python:3.10-slim-bookworm
+FROM --platform=linux/amd64 python:3.10-slim-bookworm@sha256:9643927a6fc74bd81b0f1bbb5cce3cb4a491f46b4c5dbee770f28e575f180015
 
 LABEL maintainer="Fernando Boiero <fboiero@frvm.utn.edu.ar>"
 LABEL version="6.0.0"

--- a/docs/SECURITY_ISSUES_BACKLOG.md
+++ b/docs/SECURITY_ISSUES_BACKLOG.md
@@ -31,12 +31,12 @@ This document tracks security issues identified during the security audit that r
 | MED-002 NPM pin | ✅ FIXED | `solhint@5.0.3` in both Dockerfiles |
 | MED-003 curl-to-shell | ✅ FIXED | no installer piped to a shell; Foundry/rustup enforce HTTPS/TLS1.2 + download-then-run in both Dockerfiles |
 | MED-004 Ollama auth | ✅ FIXED | main compose + `prod-llm.yml` now bind `127.0.0.1:11434` |
-| MED-005 base image | ⚠️ PARTIAL | tag-pinned; digest pin pending |
+| MED-005 base image | ✅ FIXED | base images pinned by `@sha256:` digest in both Dockerfiles; Dependabot (docker) keeps digests current |
 | MED-006 lock file | ✅ FIXED | regenerated for Python 3.12 |
 | MED-007 WebSocket auth | ✅ FIXED | `_validate_websocket_token` enforced (tested) |
 | MED-008 SSL on FS | ✅ FIXED | `*.key/*.pem/*.crt`, `ssl/` in `.gitignore` |
 
-**7 of 8 fully fixed; 1 remaining is build-time Docker hardening (MED-005 base-image digest pin).**
+**8 of 8 fully fixed.**
 The backlog was previously stale (overstated open items and understated some as fixed
 that were only partial); corrected here with per-item verification.
 
@@ -158,7 +158,7 @@ ollama:
 
 **Severity:** MEDIUM
 **CWE:** CWE-1104
-**Status:** PARTIAL (verified 2026-06-21: tag-pinned `python:3.12-slim-bookworm`; `@sha256:` digest pin still pending)
+**Status:** FIXED (2026-07-16: all `FROM` stages in `docker/Dockerfile` (python:3.12-slim-bookworm) and `docker/Dockerfile.x86` (python:3.10-slim-bookworm) pin the multi-arch manifest digest via `@sha256:`, keeping the human-readable tag. Dependabot's `docker` ecosystem (`.github/dependabot.yml`) auto-updates the digests, so base-image security patches still flow. Improves the OpenSSF Scorecard Pinned-Dependencies check.)
 
 **Location:** `docker/Dockerfile.prod:1`
 


### PR DESCRIPTION
Last open item in the security backlog. All `FROM` stages pin the multi-arch manifest digest via `@sha256:` while keeping the readable tag:
- `docker/Dockerfile` → python:3.12-slim-bookworm@sha256:d50fb761…
- `docker/Dockerfile.x86` → python:3.10-slim-bookworm@sha256:9643927a…

## Why safe (no frozen-CVE tradeoff)
`.github/dependabot.yml` already has the `docker` ecosystem, so Dependabot auto-bumps these digests — base-image security patches still flow. Improves OpenSSF Scorecard **Pinned-Dependencies**.

Backlog: **MED-005 → FIXED (8/8)**. CI docker build (multi-arch + full image) validates the pinned digests end-to-end; sequencing merge on green.