### PR TITLE
fix(benchmark): record live MIESC version in results (was hardcoded 5.1.2)

### DIFF
--- a/miesc/benchmark/benchmark_runner.py
+++ b/miesc/benchmark/benchmark_runner.py
@@ -27,6 +27,13 @@ from typing import Dict, List, Optional, Tuple
 from .dataset_loader import GroundTruth, VulnerableContract
 
 
+def _detect_miesc_version() -> str:
+    """Current MIESC version, read lazily to avoid an import cycle at module load."""
+    from miesc import __version__
+
+    return __version__
+
+
 @dataclass
 class DetectionMetrics:
     """Metrics for a single category."""
@@ -116,7 +123,7 @@ class BenchmarkResult:
     metrics_by_category: Dict[str, DetectionMetrics]
     overall_metrics: DetectionMetrics
     total_time_seconds: float
-    miesc_version: str = "5.1.2"
+    miesc_version: str = field(default_factory=_detect_miesc_version)
     config: Dict = field(default_factory=dict)
 
     @property

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -230,9 +230,13 @@ class TestBenchmarkResult:
 
     def test_create_result(self, sample_result):
         """Test creating benchmark result."""
+        from miesc import __version__ as miesc_version
+
         assert sample_result.total_contracts == 100
         assert sample_result.analyzed_contracts == 95
-        assert sample_result.miesc_version == "5.1.2"
+        # miesc_version defaults to the live package version, not a hardcoded string,
+        # so benchmark results record the version that actually produced them.
+        assert sample_result.miesc_version == miesc_version
 
     def test_success_rate(self, sample_result):
         """Test success rate calculation."""


### PR DESCRIPTION
Data-provenance fix. `BenchmarkResult.miesc_version` defaulted to the literal `"5.1.2"`, so benchmark results generated by the current v6.0.0 build were mislabeled as v5.1.2. Now defaults via a lazy factory reading `miesc.__version__` (lazy import avoids any load-time cycle), so results record the version that produced them and can't drift again. Test asserts against the live package version. 49 tests pass; ruff/black clean. Does not alter any already-generated (frozen) benchmark result files.