### PR TITLE
feat(confidence): calibrated per-finding confidence + --min-confidence filter

### DIFF
--- a/miesc/cli/commands/audit.py
+++ b/miesc/cli/commands/audit.py
@@ -418,6 +418,7 @@ def _run_full_audit_with_ml(
     verify_model: str | None = None,
     rank: bool = False,
     fp_strictness: str = "off",
+    min_confidence: float = 0.0,
     baseline_path: str | None = None,
     fail_on_new: bool = False,
 ) -> None:
@@ -461,9 +462,24 @@ def _run_full_audit_with_ml(
             except Exception as e:  # noqa: BLE001
                 info(f"verify-fp skipped: {e}")
 
+        # Confidence gate: drop findings below the calibrated-confidence threshold.
+        # The orchestrator already annotated every finding on the default path, so
+        # this runs before the report/output is written. Unannotated findings default
+        # to 1.0 and are never dropped.
+        if min_confidence and min_confidence > 0.0:
+            from miesc.core.confidence import filter_by_min_confidence
+
+            kept, dropped = filter_by_min_confidence(result.ml_filtered_findings, min_confidence)
+            result.ml_filtered_findings = kept
+            if dropped:
+                info(
+                    f"min-confidence {min_confidence}: dropped {dropped} "
+                    f"low-confidence finding(s)"
+                )
+
         # Display ML-enhanced summary
         summary_data = result.get_summary()
-        if verify_fp:
+        if verify_fp or (min_confidence and min_confidence > 0.0):
             # The ML get_summary() is computed from internal counts and does not reflect
             # the post-hoc verifier; recompute the displayed totals from the filtered set.
             _sf = summarize_findings([{"tool": "ml", "findings": result.ml_filtered_findings}])
@@ -1210,6 +1226,16 @@ def audit_quick(
     "aggressive. Default off preserves raw recall.",
 )
 @click.option(
+    "--min-confidence",
+    "min_confidence",
+    type=float,
+    default=0.0,
+    help="Drop findings whose calibrated confidence is below this threshold (0.0-1.0). "
+    "Confidence blends detector reliability, cross-tool agreement and the false-positive "
+    "signal; findings without a confidence score are always kept. Default 0.0 keeps "
+    "everything.",
+)
+@click.option(
     "--baseline",
     "baseline_path",
     type=click.Path(),
@@ -1235,6 +1261,7 @@ def audit_full(
     verify_model: str | None,
     rank: bool,
     fp_strictness: str,
+    min_confidence: float,
     baseline_path: str | None,
     fail_on_new: bool,
 ) -> None:
@@ -1276,6 +1303,7 @@ def audit_full(
             verify_model=verify_model,
             rank=rank,
             fp_strictness=fp_strictness,
+            min_confidence=min_confidence,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
         )

--- a/miesc/cli/commands/scan.py
+++ b/miesc/cli/commands/scan.py
@@ -57,6 +57,16 @@ if RICH_AVAILABLE:
     help="False positive filter strictness: off=report everything, low=permissive, medium=balanced (default), high=aggressive for CI",
 )
 @click.option(
+    "--min-confidence",
+    "min_confidence",
+    type=float,
+    default=0.0,
+    help="Drop findings whose calibrated confidence is below this threshold (0.0-1.0). "
+    "Confidence blends detector reliability, cross-tool agreement and the false-positive "
+    "signal; findings without a confidence score are always kept. Default 0.0 keeps "
+    "everything.",
+)
+@click.option(
     "--llm-enhance",
     is_flag=True,
     help="Enhance top findings with AI insights (adds ~40s, requires Ollama)",
@@ -189,6 +199,7 @@ def scan(
     ci: bool,
     quiet: bool,
     fp_strictness: str,
+    min_confidence: float,
     llm_enhance: bool,
     verbose: bool,
     recursive: bool,
@@ -310,6 +321,7 @@ def scan(
             quiet=quiet,
             verbose=verbose,
             ci=ci,
+            min_confidence=min_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -336,6 +348,7 @@ def scan(
             quiet=quiet,
             verbose=verbose,
             ci=ci,
+            min_confidence=min_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -526,6 +539,7 @@ def scan(
             quiet=quiet,
             verbose=verbose,
             ci=ci,
+            min_confidence=min_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -837,6 +851,7 @@ def scan(
         quiet=quiet,
         verbose=verbose,
         ci=ci,
+        min_confidence=min_confidence,
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
@@ -926,9 +941,10 @@ def _run_agentic_scan_profile(
     quiet: bool,
     verbose: bool,
     ci: bool,
-    verify_fp: bool,
-    verify_model: str | None,
-    rank: bool,
+    min_confidence: float = 0.0,
+    verify_fp: bool = False,
+    verify_model: str | None = None,
+    rank: bool = False,
     baseline_path: str | None = None,
     fail_on_new: bool = False,
     annotate: str | None = None,
@@ -969,6 +985,7 @@ def _run_agentic_scan_profile(
         quiet=quiet,
         verbose=verbose,
         ci=ci,
+        min_confidence=min_confidence,
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
@@ -1067,6 +1084,7 @@ def _display_and_save(
     quiet: bool,
     verbose: bool,
     ci: bool,
+    min_confidence: float = 0.0,
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
@@ -1082,6 +1100,36 @@ def _display_and_save(
         _apply_verify_fp(all_results, contract=contract, model=verify_model, quiet=quiet)
     if rank:
         _apply_triage_rank(all_results, contract=contract, quiet=quiet)
+
+    # Attach a calibrated confidence score to every scan finding (scan runs its own
+    # adapter + FP-filter pipeline, so findings arrive un-annotated). Mirrors the ML
+    # orchestrator's default path, then applies the --min-confidence gate before the
+    # summary/report is written. Best-effort: never breaks the scan.
+    try:
+        from miesc.core.confidence import annotate_confidence, filter_by_min_confidence
+
+        try:
+            contract_source = (
+                Path(contract).read_text(encoding="utf-8") if Path(contract).is_file() else ""
+            )
+        except Exception:
+            contract_source = ""
+        for result in all_results:
+            annotate_confidence(result.get("findings", []), contract_source, str(contract))
+        if min_confidence and min_confidence > 0.0:
+            dropped_total = 0
+            for result in all_results:
+                kept, dropped = filter_by_min_confidence(result.get("findings", []), min_confidence)
+                result["findings"] = kept
+                dropped_total += dropped
+            if not quiet and dropped_total:
+                info(
+                    f"min-confidence {min_confidence}: dropped {dropped_total} "
+                    f"low-confidence finding(s)"
+                )
+    except Exception as e:  # noqa: BLE001
+        if not quiet:
+            info(f"confidence annotation skipped: {e}")
     # Detect tool failures — help users who installed miesc without slither/aderyn
     tools_succeeded = [r for r in all_results if r.get("status") != "error"]
     tools_errored = [r for r in all_results if r.get("status") == "error"]

--- a/miesc/core/confidence.py
+++ b/miesc/core/confidence.py
@@ -20,10 +20,13 @@ running the full (heavier) correlation pass.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from miesc.ml.correlation_engine import SmartCorrelationEngine
+
+logger = logging.getLogger(__name__)
 
 # Reuse the correlation engine's calibrated priors so tool trust lives in ONE
 # place. If the engine grows/retunes a tool weight, confidence follows.
@@ -111,3 +114,69 @@ class ConfidenceCalibrator:
             tool_count=tool_count,
             contributing_tools=distinct,
         )
+
+
+def annotate_confidence(
+    findings: Sequence[Dict[str, Any]],
+    contract_source: str = "",
+    contract_path: str = "",
+) -> None:
+    """Attach a calibrated ``confidence`` (0-1) and ``confidence_level`` to each
+    finding, in place.
+
+    Blends the detector reliability prior, cross-tool agreement (the ``tools``
+    provenance list) and the benign-context FP probability. Best-effort: a failure
+    never breaks the caller, it just leaves confidence unset. This is the single
+    source of truth shared by the ML orchestrator (default ``analyze`` path) and the
+    ``scan`` CLI, so both annotate findings identically.
+    """
+    try:
+        from miesc.ml.fp_filter import FalsePositiveFilter
+
+        calibrator = ConfidenceCalibrator()
+        fp_scorer = FalsePositiveFilter(strictness="high", use_rag=False)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Confidence calibration unavailable: %s", e)
+        return
+
+    for finding in findings:
+        try:
+            tools = finding.get("tools") or ([finding["tool"]] if finding.get("tool") else [])
+            vuln_type = finding.get("type") or finding.get("check") or finding.get("swc") or ""
+            try:
+                fp_probability = fp_scorer.filter_finding(
+                    finding, code_context=contract_source, file_path=contract_path
+                ).fp_probability
+            except Exception:
+                fp_probability = None
+            result = calibrator.calibrate(tools, vuln_type, fp_probability)
+            finding["confidence"] = result.score
+            finding["confidence_level"] = result.level
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Confidence calibration skipped for a finding: %s", e)
+
+
+def filter_by_min_confidence(
+    findings: Sequence[Dict[str, Any]],
+    min_confidence: float,
+) -> "tuple[List[Dict[str, Any]], int]":
+    """Drop findings whose calibrated ``confidence`` is below ``min_confidence``.
+
+    Findings without a ``confidence`` key default to ``1.0`` so that unannotated
+    findings are never silently dropped. A non-positive threshold is a no-op.
+    Returns ``(kept, dropped_count)``.
+    """
+    if not min_confidence or min_confidence <= 0.0:
+        return list(findings), 0
+    kept: List[Dict[str, Any]] = []
+    dropped = 0
+    for f in findings:
+        try:
+            score = float(f.get("confidence", 1.0))
+        except (TypeError, ValueError):
+            score = 1.0
+        if score >= min_confidence:
+            kept.append(f)
+        else:
+            dropped += 1
+    return kept, dropped

--- a/miesc/core/confidence.py
+++ b/miesc/core/confidence.py
@@ -1,0 +1,113 @@
+"""Calibrated per-finding confidence scoring.
+
+Blends three signals that already flow through the analysis pipeline into a
+single ``[0, 1]`` confidence score, so findings can be ranked and filtered by how
+much we trust them:
+
+- **detector reliability prior** — per-tool trust, reused from the correlation
+  engine's ``TOOL_WEIGHTS`` so there is a single source of truth for how much
+  each tool is believed;
+- **cross-tool agreement** — independent tools reporting the *same* finding raise
+  confidence;
+- **false-positive signal** — the benign-context FP filter's probability that the
+  finding is noise pulls confidence down.
+
+The correlation engine already computed a richer version of this, but it is
+dormant on the default ``scan``/``audit`` path. This module surfaces the same
+idea, reusing the engine's calibrated priors, onto that default path without
+running the full (heavier) correlation pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from miesc.ml.correlation_engine import SmartCorrelationEngine
+
+# Reuse the correlation engine's calibrated priors so tool trust lives in ONE
+# place. If the engine grows/retunes a tool weight, confidence follows.
+_TOOL_WEIGHTS = SmartCorrelationEngine.TOOL_WEIGHTS
+_CROSS_VALIDATION_REQUIRED = SmartCorrelationEngine.CROSS_VALIDATION_REQUIRED
+_SINGLE_TOOL_MAX_CONFIDENCE = SmartCorrelationEngine.SINGLE_TOOL_MAX_CONFIDENCE
+_DEFAULT_TOOL_WEIGHT = 0.50  # unknown tool: neutral prior
+
+HIGH_THRESHOLD = 0.70
+MEDIUM_THRESHOLD = 0.40
+
+
+@dataclass
+class ConfidenceResult:
+    """Outcome of calibrating one finding."""
+
+    score: float  # calibrated confidence in [0, 1]
+    level: str  # "high" | "medium" | "low"
+    tool_count: int  # number of distinct tools that reported the finding
+    contributing_tools: List[str] = field(default_factory=list)
+
+
+def confidence_level(score: float) -> str:
+    """Bucket a raw score into a human-facing level."""
+    if score >= HIGH_THRESHOLD:
+        return "high"
+    if score >= MEDIUM_THRESHOLD:
+        return "medium"
+    return "low"
+
+
+def _detector_prior(tools: Sequence[str]) -> float:
+    """Best per-tool reliability prior among the reporting tools."""
+    weights = [_TOOL_WEIGHTS.get((t or "").lower(), _DEFAULT_TOOL_WEIGHT) for t in tools]
+    return max(weights) if weights else _DEFAULT_TOOL_WEIGHT
+
+
+def _requires_cross_validation(vuln_type: str) -> bool:
+    v = (vuln_type or "").lower()
+    return any(pattern in v for pattern in _CROSS_VALIDATION_REQUIRED)
+
+
+class ConfidenceCalibrator:
+    """Stateless calibrator combining detector prior, agreement and FP signal.
+
+    ``calibrate`` never raises on odd input: missing tools fall back to the neutral
+    prior, and ``fp_probability=None`` simply skips the FP penalty.
+    """
+
+    AGREEMENT_BONUS = 0.05  # added per additional confirming tool
+    MAX_AGREEMENT_TOOLS = 3  # bonus saturates after this many extra tools
+    CAP = 0.99  # never claim certainty
+
+    def calibrate(
+        self,
+        tools: Sequence[str],
+        vuln_type: str = "",
+        fp_probability: Optional[float] = None,
+    ) -> ConfidenceResult:
+        # Distinct tools, order preserved; drop empties.
+        distinct = list(dict.fromkeys(t for t in tools if t))
+        tool_count = max(len(distinct), 1)
+
+        # 1) start from the most reliable reporting tool
+        score = _detector_prior(distinct)
+
+        # 2) cross-tool agreement raises confidence
+        extra = min(tool_count - 1, self.MAX_AGREEMENT_TOOLS)
+        score += self.AGREEMENT_BONUS * extra
+
+        # 3) the false-positive signal pulls it down
+        if fp_probability is not None:
+            score *= 1.0 - max(0.0, min(1.0, fp_probability))
+
+        # 4) a single tool on a cross-validation-required pattern is capped:
+        #    these types have a high single-tool FP rate, so one tool is not enough
+        #    to be confident regardless of that tool's prior.
+        if tool_count < 2 and _requires_cross_validation(vuln_type):
+            score = min(score, _SINGLE_TOOL_MAX_CONFIDENCE)
+
+        score = round(max(0.0, min(self.CAP, score)), 2)
+        return ConfidenceResult(
+            score=score,
+            level=confidence_level(score),
+            tool_count=tool_count,
+            contributing_tools=distinct,
+        )

--- a/miesc/core/exporters.py
+++ b/miesc/core/exporters.py
@@ -169,6 +169,9 @@ class SARIFExporter:
         result = {
             "ruleId": self._get_rule_id(finding),
             "level": self._severity_to_level(finding.severity),
+            # SARIF rank (0-100): calibrated confidence, so viewers can sort/triage
+            # by trust. Mirrors properties.confidence in the spec's dedicated slot.
+            "rank": round(finding.confidence * 100, 1),
             "message": {"text": finding.description},
             "locations": [
                 {

--- a/miesc/core/ml_orchestrator.py
+++ b/miesc/core/ml_orchestrator.py
@@ -513,32 +513,13 @@ class MLOrchestrator:
         Blends the detector reliability prior, cross-tool agreement (the ``tools``
         provenance list) and the benign-context FP probability. Best-effort: a
         failure never breaks the analysis, it just leaves confidence unset.
+
+        Delegates to :func:`miesc.core.confidence.annotate_confidence` so the ML
+        orchestrator and the ``scan`` CLI share one calibration implementation.
         """
-        try:
-            from miesc.core.confidence import ConfidenceCalibrator
-            from miesc.ml.fp_filter import FalsePositiveFilter
+        from miesc.core.confidence import annotate_confidence
 
-            calibrator = ConfidenceCalibrator()
-            fp_scorer = FalsePositiveFilter(strictness="high", use_rag=False)
-        except Exception as e:  # pragma: no cover - defensive
-            logger.warning("Confidence calibration unavailable: %s", e)
-            return
-
-        for finding in findings:
-            try:
-                tools = finding.get("tools") or ([finding["tool"]] if finding.get("tool") else [])
-                vuln_type = finding.get("type") or finding.get("check") or finding.get("swc") or ""
-                try:
-                    fp_probability = fp_scorer.filter_finding(
-                        finding, code_context=contract_source, file_path=contract_path
-                    ).fp_probability
-                except Exception:
-                    fp_probability = None
-                result = calibrator.calibrate(tools, vuln_type, fp_probability)
-                finding["confidence"] = result.score
-                finding["confidence_level"] = result.level
-            except Exception as e:  # pragma: no cover - defensive
-                logger.debug("Confidence calibration skipped for a finding: %s", e)
+        annotate_confidence(findings, contract_source, contract_path)
 
     def _is_same_location(self, f1: Dict[str, Any], f2: Dict[str, Any]) -> bool:
         """Verifica si dos hallazgos están en la misma ubicación."""

--- a/miesc/core/ml_orchestrator.py
+++ b/miesc/core/ml_orchestrator.py
@@ -410,6 +410,11 @@ class MLOrchestrator:
                 duplicates_collapsed,
             )
 
+        # Attach a calibrated confidence score to every finding (detector prior +
+        # cross-tool agreement + FP signal), so consumers can rank and filter by
+        # trust. Runs on the default path, not only under --correlate.
+        self._annotate_confidence(ml_filtered_findings, contract_source, contract_path)
+
         # Calculate severity distribution
         severity_dist = self._calculate_severity_distribution(ml_filtered_findings)
 
@@ -495,6 +500,45 @@ class MLOrchestrator:
                 grouped[k] = rep
                 order.append(k)
         return [grouped[k] for k in order], collapsed
+
+    def _annotate_confidence(
+        self,
+        findings: List[Dict[str, Any]],
+        contract_source: str,
+        contract_path: str,
+    ) -> None:
+        """Attach a calibrated ``confidence`` (0-1) and ``confidence_level`` to each
+        finding, in place.
+
+        Blends the detector reliability prior, cross-tool agreement (the ``tools``
+        provenance list) and the benign-context FP probability. Best-effort: a
+        failure never breaks the analysis, it just leaves confidence unset.
+        """
+        try:
+            from miesc.core.confidence import ConfidenceCalibrator
+            from miesc.ml.fp_filter import FalsePositiveFilter
+
+            calibrator = ConfidenceCalibrator()
+            fp_scorer = FalsePositiveFilter(strictness="high", use_rag=False)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Confidence calibration unavailable: %s", e)
+            return
+
+        for finding in findings:
+            try:
+                tools = finding.get("tools") or ([finding["tool"]] if finding.get("tool") else [])
+                vuln_type = finding.get("type") or finding.get("check") or finding.get("swc") or ""
+                try:
+                    fp_probability = fp_scorer.filter_finding(
+                        finding, code_context=contract_source, file_path=contract_path
+                    ).fp_probability
+                except Exception:
+                    fp_probability = None
+                result = calibrator.calibrate(tools, vuln_type, fp_probability)
+                finding["confidence"] = result.score
+                finding["confidence_level"] = result.level
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("Confidence calibration skipped for a finding: %s", e)
 
     def _is_same_location(self, f1: Dict[str, Any], f2: Dict[str, Any]) -> bool:
         """Verifica si dos hallazgos están en la misma ubicación."""

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,87 @@
+"""Unit tests for the per-finding confidence calibrator.
+
+The calibrator blends detector reliability priors (reused from the correlation
+engine), cross-tool agreement, and the false-positive signal. These tests pin the
+invariants that make the score meaningful: agreement raises it, the FP signal
+lowers it, single-tool critical findings are capped, and levels bucket correctly.
+"""
+
+import unittest
+
+from miesc.core.confidence import (
+    HIGH_THRESHOLD,
+    MEDIUM_THRESHOLD,
+    ConfidenceCalibrator,
+    confidence_level,
+)
+
+
+class TestConfidenceCalibrator(unittest.TestCase):
+    def setUp(self):
+        self.cal = ConfidenceCalibrator()
+
+    def test_more_tools_raise_confidence(self):
+        one = self.cal.calibrate(["slither"], "unchecked-call").score
+        three = self.cal.calibrate(["slither", "mythril", "aderyn"], "unchecked-call").score
+        self.assertGreater(three, one, "cross-tool agreement must raise confidence")
+
+    def test_fp_signal_lowers_confidence(self):
+        clean = self.cal.calibrate(["slither"], "solc-version", fp_probability=0.0).score
+        benign = self.cal.calibrate(["slither"], "solc-version", fp_probability=0.8).score
+        self.assertLess(benign, clean, "a high FP probability must pull confidence down")
+        self.assertLess(benign, 0.3, "a likely-benign single-tool finding should score low")
+
+    def test_benign_single_tool_is_low_level(self):
+        # The motivating case: solc-version on modern code, one tool, likely benign.
+        r = self.cal.calibrate(["slither"], "solc-version", fp_probability=0.8)
+        self.assertEqual(r.level, "low")
+
+    def test_agreeing_real_vuln_is_high_level(self):
+        # Three tools agree on reentrancy with a low FP signal -> high confidence.
+        r = self.cal.calibrate(
+            ["slither", "mythril", "aderyn"], "reentrancy-eth", fp_probability=0.05
+        )
+        self.assertEqual(r.level, "high")
+        self.assertEqual(r.tool_count, 3)
+        self.assertEqual(set(r.contributing_tools), {"slither", "mythril", "aderyn"})
+
+    def test_single_tool_cross_validation_pattern_is_capped(self):
+        # reentrancy is cross-validation-required: one tool cannot exceed the cap
+        # even with a perfect prior and no FP signal.
+        r = self.cal.calibrate(["certora"], "reentrancy", fp_probability=0.0)
+        self.assertLessEqual(r.score, 0.60, "single tool on a critical pattern must be capped")
+
+    def test_multi_tool_cross_validation_pattern_not_capped(self):
+        # With two tools the cap no longer applies.
+        r = self.cal.calibrate(["slither", "mythril"], "reentrancy", fp_probability=0.0)
+        self.assertGreater(r.score, 0.60)
+
+    def test_unknown_tool_uses_neutral_prior(self):
+        r = self.cal.calibrate(["some-unknown-tool"], "reentrancy-events", fp_probability=0.0)
+        # neutral prior 0.50, single-tool critical cap 0.60 -> stays at prior
+        self.assertAlmostEqual(r.score, 0.50, places=2)
+
+    def test_empty_tools_does_not_crash(self):
+        r = self.cal.calibrate([], "", fp_probability=None)
+        self.assertEqual(r.tool_count, 1)
+        self.assertGreaterEqual(r.score, 0.0)
+
+    def test_duplicate_tools_counted_once(self):
+        r = self.cal.calibrate(["slither", "slither"], "unchecked-call")
+        self.assertEqual(r.tool_count, 1)
+
+    def test_score_is_bounded(self):
+        r = self.cal.calibrate(
+            ["certora", "smtchecker", "echidna", "foundry"], "unchecked-call", fp_probability=0.0
+        )
+        self.assertLessEqual(r.score, 0.99)
+        self.assertGreaterEqual(r.score, 0.0)
+
+    def test_level_thresholds(self):
+        self.assertEqual(confidence_level(HIGH_THRESHOLD), "high")
+        self.assertEqual(confidence_level(MEDIUM_THRESHOLD), "medium")
+        self.assertEqual(confidence_level(MEDIUM_THRESHOLD - 0.01), "low")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_confidence_integration.py
+++ b/tests/test_confidence_integration.py
@@ -1,0 +1,197 @@
+"""Integration tests for calibrated finding confidence.
+
+These exercise confidence end-to-end rather than the calibrator in isolation:
+
+- the ML orchestrator's default ``analyze`` path annotates each surviving finding
+  with a calibrated ``confidence``/``confidence_level`` (cross-tool agreement raises
+  it, a benign single-tool finding stays low);
+- the ``--min-confidence`` CLI gate drops low-confidence findings before the report
+  is written, while keeping high-confidence ones;
+- the SARIF ``rank`` reflects the calibrated confidence.
+"""
+
+import json
+import unittest
+from unittest import mock
+
+from click.testing import CliRunner
+
+from miesc.cli.commands.scan import scan
+from miesc.core.exporters import Finding, SARIFExporter
+from miesc.core.ml_orchestrator import MLOrchestrator
+
+# Modern contract: the reentrancy is real, the solc-version pragma is benign.
+MODERN_CODE = """
+pragma solidity ^0.8.0;
+contract Bank {
+    mapping(address => uint) balances;
+    function withdraw() external {
+        uint amt = balances[msg.sender];
+        (bool ok, ) = msg.sender.call{value: amt}("");
+        require(ok);
+        balances[msg.sender] = 0;
+    }
+}
+"""
+
+
+def _tool_result(finding_template: dict):
+    """Build a per-tool ``_run_tool`` side effect returning a FRESH copy of the
+    finding for each call, so the orchestrator can tag each with its own tool and
+    then collapse the exact duplicates (merging the ``tools`` provenance list)."""
+
+    def _side_effect(tool_name, contract_path, timeout=120):
+        return {
+            "tool": tool_name,
+            "status": "success",
+            "findings": [dict(finding_template)],
+        }
+
+    return _side_effect
+
+
+class TestOrchestratorConfidenceAnnotation(unittest.TestCase):
+    """The default analyze() path attaches a calibrated confidence to findings."""
+
+    def _analyze(self, tools, finding_template):
+        orch = MLOrchestrator(ml_enabled=False)
+        with (
+            mock.patch.object(orch, "_read_contract_source", return_value=MODERN_CODE),
+            mock.patch.object(orch, "_determine_tools", return_value=tools),
+            mock.patch.object(orch, "_run_tool", side_effect=_tool_result(finding_template)),
+        ):
+            return orch.analyze("Bank.sol")
+
+    def test_multi_tool_reentrancy_is_high_confidence(self):
+        # Three distinct tools report the same reentrancy at the same location: the
+        # exact duplicates collapse into one survivor whose provenance lists all
+        # three tools, and cross-tool agreement pushes confidence to "high".
+        finding = {
+            "type": "reentrancy-eth",
+            "check": "reentrancy-eth",
+            "swc": "SWC-107",
+            "title": "Reentrancy",
+            "severity": "high",
+            "location": {"file": "Bank.sol", "line": 6},
+        }
+        result = self._analyze(["slither", "mythril", "aderyn"], finding)
+
+        self.assertEqual(len(result.ml_filtered_findings), 1, "exact duplicates must collapse")
+        survivor = result.ml_filtered_findings[0]
+        self.assertEqual(set(survivor["tools"]), {"slither", "mythril", "aderyn"})
+        self.assertEqual(survivor["confidence_level"], "high")
+        self.assertGreaterEqual(survivor["confidence"], 0.70)
+
+    def test_benign_single_tool_finding_is_low_confidence(self):
+        # A single tool reporting solc-version on a modern contract is the canonical
+        # benign finding: one tool + a high FP signal keeps confidence "low".
+        finding = {
+            "type": "solc-version",
+            "check": "solc-version",
+            "swc": "SWC-103",
+            "title": "solc-version",
+            "severity": "informational",
+            "location": {"file": "Bank.sol", "line": 2},
+        }
+        result = self._analyze(["slither"], finding)
+
+        self.assertEqual(len(result.ml_filtered_findings), 1)
+        survivor = result.ml_filtered_findings[0]
+        self.assertEqual(survivor["confidence_level"], "low")
+
+
+class TestScanMinConfidenceGate(unittest.TestCase):
+    """`miesc scan --min-confidence` drops low-confidence findings before output."""
+
+    @staticmethod
+    def _fake_annotate(findings, contract_source="", contract_path=""):
+        # Deterministic stand-in for the real calibrator: high for reentrancy, low
+        # for solc-version, so the min-confidence gate has a clear boundary to cut on.
+        for f in findings:
+            if f.get("type") == "reentrancy":
+                f["confidence"], f["confidence_level"] = 0.90, "high"
+            else:
+                f["confidence"], f["confidence_level"] = 0.20, "low"
+
+    @staticmethod
+    def _fake_run_tool(tool, contract, timeout=300, **kwargs):
+        return {
+            "tool": tool,
+            "status": "success",
+            "findings": [
+                {
+                    "type": "reentrancy",
+                    "title": "Reentrancy",
+                    "severity": "high",
+                    "location": {"file": "C.sol", "line": 5},
+                },
+                {
+                    "type": "solc-version",
+                    "title": "solc-version",
+                    "severity": "informational",
+                    "location": {"file": "C.sol", "line": 1},
+                },
+            ],
+        }
+
+    def test_min_confidence_drops_low_keeps_high(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("C.sol", "w", encoding="utf-8") as fh:
+                fh.write("pragma solidity ^0.8.0; contract C {}\n")
+
+            with (
+                mock.patch("miesc.cli.commands.scan.run_tool", self._fake_run_tool),
+                mock.patch(
+                    "miesc.core.intelligence.enhance_findings",
+                    side_effect=lambda findings, **kw: findings,
+                ),
+                mock.patch("miesc.core.confidence.annotate_confidence", self._fake_annotate),
+            ):
+                res = runner.invoke(
+                    scan,
+                    [
+                        "C.sol",
+                        "--fp-strictness",
+                        "off",
+                        "--min-confidence",
+                        "0.5",
+                        "-o",
+                        "out.json",
+                        "-q",
+                    ],
+                )
+
+            self.assertEqual(res.exit_code, 0, res.output)
+            with open("out.json", encoding="utf-8") as fh:
+                data = json.load(fh)
+
+            types = {f.get("type") for f in data["findings"]}
+            self.assertIn("reentrancy", types, "high-confidence finding must be kept")
+            self.assertNotIn("solc-version", types, "low-confidence finding must be dropped")
+            self.assertTrue(all(f["confidence"] >= 0.5 for f in data["findings"]))
+
+
+class TestSarifRankReflectsConfidence(unittest.TestCase):
+    """SARIF ``rank`` (0-100) mirrors the calibrated confidence."""
+
+    def test_confidence_0_9_yields_rank_90(self):
+        finding_dict = {"confidence": 0.9}
+        finding = Finding(
+            id="1",
+            type="reentrancy",
+            severity="high",
+            title="Reentrancy",
+            description="reentrancy in withdraw",
+            file_path="C.sol",
+            line_start=5,
+            confidence=finding_dict.get("confidence", 0.8),
+        )
+        sarif = json.loads(SARIFExporter().export([finding]))
+        result = sarif["runs"][0]["results"][0]
+        self.assertEqual(result["rank"], 90.0)
+        self.assertEqual(result["properties"]["confidence"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Surfaces a **calibrated confidence score** on every finding and lets users filter by it. The correlation engine already computed a rich confidence, but it was **dormant** — only reachable via `audit full --no-ml --correlate`, never on `scan` or the default `audit`. This wakes that idea up on the default path, reusing the engine's priors instead of duplicating them.

## What
- **`miesc/core/confidence.py`** — `ConfidenceCalibrator`: blends the detector reliability prior (reused from `SmartCorrelationEngine.TOOL_WEIGHTS` — single source of truth for tool trust), cross-tool agreement (the `tools` provenance list), and the benign-context FP probability. Single-tool findings on cross-validation-required patterns are capped, matching the engine's policy. Shared helpers `annotate_confidence` + `filter_by_min_confidence`.
- Wired into **`MLOrchestrator.analyze()`** (default audit path) and **`scan`** (its own pipeline, annotated at the `_display_and_save` chokepoint) — every finding gets `confidence` (0-1) + `confidence_level`.
- **`--min-confidence FLOAT`** on `scan` and `audit full` (default 0.0 = keep everything; findings without a score are never dropped).
- **SARIF** `rank` slot (previously unused) now carries confidence×100 alongside `properties.confidence`.

## Behavior (matches the design)
```
reentrancy @ Bank.sol:22 · slither+mythril+aderyn (3/3) · fp low  → 0.90 [high]
solc-version @ *.sol:1   · slither (1) · fp likely-benign         → 0.17 [low]
$ miesc scan c.sol --min-confidence 0.5   # drops the noise
```

## Tests / safety
15 confidence tests (calibrator units + integration: multi-tool→high, benign→low, `--min-confidence` filter, SARIF rank). Broader scan/audit/export/exporters regression green (168 passed locally). ruff + black clean. Reuses existing priors + FP signal; no new engine, no external deps. Sequencing merge on green CI (touches shared modules: ml_orchestrator, scan, audit).