### PR TITLE
feat(cli): --fail-on-confidence CI gate for scan and audit full

### DIFF
--- a/miesc/cli/commands/audit.py
+++ b/miesc/cli/commands/audit.py
@@ -407,6 +407,35 @@ def _ml_result_to_markdown(result: Any, contract: str) -> str:
 # =============================================================================
 
 
+def _apply_ci_gate(
+    results: List[Dict[str, Any]],
+    *,
+    ci: bool,
+    fail_on_confidence: float,
+) -> None:
+    """Exit non-zero in CI mode when confident critical/high findings remain.
+
+    When ``fail_on_confidence > 0`` the gate counts ONLY findings whose calibrated
+    confidence meets the threshold (via ``filter_results_by_confidence``), leaving the
+    reported/saved findings untouched; otherwise it gates on every finding. A no-op
+    unless ``ci`` is set.
+    """
+    if not ci:
+        return
+    gate_results = results
+    if fail_on_confidence and fail_on_confidence > 0.0:
+        from miesc.core.confidence import filter_results_by_confidence
+
+        gate_results = filter_results_by_confidence(results, fail_on_confidence)
+    summary = summarize_findings(gate_results)
+    if summary.get("CRITICAL", 0) > 0 or summary.get("HIGH", 0) > 0:
+        error(
+            f"Found {summary.get('CRITICAL', 0)} critical and "
+            f"{summary.get('HIGH', 0)} high issues"
+        )
+        sys.exit(1)
+
+
 def _run_full_audit_with_ml(
     contract: str,
     output: str | None,
@@ -419,6 +448,8 @@ def _run_full_audit_with_ml(
     rank: bool = False,
     fp_strictness: str = "off",
     min_confidence: float = 0.0,
+    ci: bool = False,
+    fail_on_confidence: float = 0.0,
     baseline_path: str | None = None,
     fail_on_new: bool = False,
 ) -> None:
@@ -572,6 +603,13 @@ def _run_full_audit_with_ml(
                 fail_on_new=fail_on_new,
             )
 
+        # Confidence-aware CI gate (exit only; report/output already written above).
+        _apply_ci_gate(
+            [{"tool": "ml", "findings": list(result.ml_filtered_findings)}],
+            ci=ci,
+            fail_on_confidence=fail_on_confidence,
+        )
+
     except Exception as e:
         error(f"ML analysis failed: {e}")
         logger.exception("ML analysis error")
@@ -585,6 +623,8 @@ def _run_full_audit_with_ml(
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
+            ci=ci,
+            fail_on_confidence=fail_on_confidence,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
         )
@@ -633,6 +673,8 @@ def _run_full_audit_with_correlation(
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
+    ci: bool = False,
+    fail_on_confidence: float = 0.0,
     baseline_path: str | None = None,
     fail_on_new: bool = False,
 ) -> None:
@@ -725,6 +767,10 @@ def _run_full_audit_with_correlation(
         gate_findings = [f for r in all_results for f in r.get("findings", [])]
         apply_baseline_gate(gate_findings, baseline_path, fail_on_new=fail_on_new)
 
+    # Confidence-aware CI gate on the raw per-layer findings (the correlation report
+    # summary has no per-severity counts). Exit only; the report/output is unchanged.
+    _apply_ci_gate(all_results, ci=ci, fail_on_confidence=fail_on_confidence)
+
 
 def _run_full_audit_basic(
     contract: str,
@@ -735,6 +781,8 @@ def _run_full_audit_basic(
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
+    ci: bool = False,
+    fail_on_confidence: float = 0.0,
     baseline_path: str | None = None,
     fail_on_new: bool = False,
 ) -> None:
@@ -921,6 +969,9 @@ def _run_full_audit_basic(
 
         gate_findings = [f for r in all_results for f in r.get("findings", [])]
         apply_baseline_gate(gate_findings, baseline_path, fail_on_new=fail_on_new)
+
+    # Confidence-aware CI gate (exit only; the report/output above is unchanged).
+    _apply_ci_gate(all_results, ci=ci, fail_on_confidence=fail_on_confidence)
 
 
 # =============================================================================
@@ -1235,6 +1286,16 @@ def audit_quick(
     "signal; findings without a confidence score are always kept. Default 0.0 keeps "
     "everything.",
 )
+@click.option("--ci", is_flag=True, help="CI mode: exit with error if critical/high issues found")
+@click.option(
+    "--fail-on-confidence",
+    "fail_on_confidence",
+    type=float,
+    default=0.0,
+    help="Only trip the CI gate (--ci) on findings whose calibrated confidence is >= "
+    "this threshold (0.0-1.0). Findings are still reported in full; this affects only "
+    "the exit code. Default 0.0 gates on everything.",
+)
 @click.option(
     "--baseline",
     "baseline_path",
@@ -1262,6 +1323,8 @@ def audit_full(
     rank: bool,
     fp_strictness: str,
     min_confidence: float,
+    ci: bool,
+    fail_on_confidence: float,
     baseline_path: str | None,
     fail_on_new: bool,
 ) -> None:
@@ -1304,6 +1367,8 @@ def audit_full(
             rank=rank,
             fp_strictness=fp_strictness,
             min_confidence=min_confidence,
+            ci=ci,
+            fail_on_confidence=fail_on_confidence,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
         )
@@ -1325,6 +1390,8 @@ def audit_full(
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
+            ci=ci,
+            fail_on_confidence=fail_on_confidence,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
         )
@@ -1342,6 +1409,8 @@ def audit_full(
         timeout,
         verify_fp=verify_fp,
         verify_model=verify_model,
+        ci=ci,
+        fail_on_confidence=fail_on_confidence,
         baseline_path=baseline_path,
         fail_on_new=fail_on_new,
     )

--- a/miesc/cli/commands/scan.py
+++ b/miesc/cli/commands/scan.py
@@ -67,6 +67,15 @@ if RICH_AVAILABLE:
     "everything.",
 )
 @click.option(
+    "--fail-on-confidence",
+    "fail_on_confidence",
+    type=float,
+    default=0.0,
+    help="Only trip the CI gate (--ci / --fail-on) on findings whose calibrated "
+    "confidence is >= this threshold (0.0-1.0). Findings are still reported in full; "
+    "this affects only the exit code. Default 0.0 gates on everything.",
+)
+@click.option(
     "--llm-enhance",
     is_flag=True,
     help="Enhance top findings with AI insights (adds ~40s, requires Ollama)",
@@ -200,6 +209,7 @@ def scan(
     quiet: bool,
     fp_strictness: str,
     min_confidence: float,
+    fail_on_confidence: float,
     llm_enhance: bool,
     verbose: bool,
     recursive: bool,
@@ -322,6 +332,7 @@ def scan(
             verbose=verbose,
             ci=ci,
             min_confidence=min_confidence,
+            fail_on_confidence=fail_on_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -349,6 +360,7 @@ def scan(
             verbose=verbose,
             ci=ci,
             min_confidence=min_confidence,
+            fail_on_confidence=fail_on_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -540,6 +552,7 @@ def scan(
             verbose=verbose,
             ci=ci,
             min_confidence=min_confidence,
+            fail_on_confidence=fail_on_confidence,
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
@@ -852,6 +865,7 @@ def scan(
         verbose=verbose,
         ci=ci,
         min_confidence=min_confidence,
+        fail_on_confidence=fail_on_confidence,
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
@@ -942,6 +956,7 @@ def _run_agentic_scan_profile(
     verbose: bool,
     ci: bool,
     min_confidence: float = 0.0,
+    fail_on_confidence: float = 0.0,
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
@@ -986,6 +1001,7 @@ def _run_agentic_scan_profile(
         verbose=verbose,
         ci=ci,
         min_confidence=min_confidence,
+        fail_on_confidence=fail_on_confidence,
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
@@ -1085,6 +1101,7 @@ def _display_and_save(
     verbose: bool,
     ci: bool,
     min_confidence: float = 0.0,
+    fail_on_confidence: float = 0.0,
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
@@ -1145,6 +1162,20 @@ def _display_and_save(
     summary = summarize_findings(all_results)
     total = sum(summary.values())
     critical_high = summary.get("CRITICAL", 0) + summary.get("HIGH", 0)
+
+    # CI-gate severity: identical to the displayed counts unless --fail-on-confidence
+    # is set, in which case the gate only counts findings meeting the confidence
+    # threshold. The displayed summary/output above still reflect ALL findings; only
+    # the exit decision (and the notification's ci_failed flag) use this value.
+    if fail_on_confidence and fail_on_confidence > 0.0:
+        from miesc.core.confidence import filter_results_by_confidence
+
+        gate_summary = summarize_findings(
+            filter_results_by_confidence(all_results, fail_on_confidence)
+        )
+        gate_critical_high = gate_summary.get("CRITICAL", 0) + gate_summary.get("HIGH", 0)
+    else:
+        gate_critical_high = critical_high
 
     # Display summary
     if RICH_AVAILABLE:
@@ -1298,13 +1329,13 @@ def _display_and_save(
             webhook_url=notify_url,
             slack_url=slack_url,
             min_severity=notify_min_severity,
-            ci_failed=critical_high > 0,
+            ci_failed=gate_critical_high > 0,
         )
         if not quiet:
             for sink, ok in delivered.items():
                 info(f"notify[{sink}]: {'sent' if ok else 'skipped/failed'}")
 
     # CI mode exit
-    if ci and critical_high > 0:
-        error(f"CI check failed: {critical_high} critical/high issues")
+    if ci and gate_critical_high > 0:
+        error(f"CI check failed: {gate_critical_high} critical/high issues")
         sys.exit(1)

--- a/miesc/core/confidence.py
+++ b/miesc/core/confidence.py
@@ -180,3 +180,30 @@ def filter_by_min_confidence(
         else:
             dropped += 1
     return kept, dropped
+
+
+def filter_results_by_confidence(
+    results: Sequence[Dict[str, Any]],
+    min_confidence: float,
+) -> List[Dict[str, Any]]:
+    """Return shallow copies of ``results`` with low-confidence findings removed.
+
+    ``results`` is the CLI's per-tool result structure: a list of dicts each with a
+    ``"findings"`` list. Each result is shallow-copied and its ``findings`` replaced
+    by those meeting ``min_confidence`` (delegating to :func:`filter_by_min_confidence`,
+    so findings without a ``confidence`` key are kept). A non-positive threshold
+    returns shallow copies unchanged.
+
+    Neither the input ``results`` list, the input result dicts, nor their finding
+    dicts are mutated. This lets callers compute a CI-gate severity summary over the
+    confident subset WITHOUT altering the findings that are reported/saved.
+    """
+    if not min_confidence or min_confidence <= 0.0:
+        return [dict(r) for r in results]
+    out: List[Dict[str, Any]] = []
+    for r in results:
+        new_r = dict(r)
+        kept, _ = filter_by_min_confidence(r.get("findings", []), min_confidence)
+        new_r["findings"] = kept
+        out.append(new_r)
+    return out

--- a/tests/test_fail_on_confidence.py
+++ b/tests/test_fail_on_confidence.py
@@ -1,0 +1,135 @@
+"""Tests for the --fail-on-confidence CI gate.
+
+``--fail-on-confidence`` is distinct from ``--min-confidence``: it hides nothing
+from the report, it only narrows which findings can trip the CI exit code. The
+gate counts only findings whose calibrated confidence meets the threshold, while
+the reported/saved findings still reflect everything.
+
+Author: Fernando Boiero
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from miesc.cli.commands.scan import scan
+from miesc.core.confidence import filter_results_by_confidence
+
+SCAN = "miesc.cli.commands.scan"
+
+
+# ===========================================================================
+# Unit: filter_results_by_confidence
+# ===========================================================================
+
+
+class TestFilterResultsByConfidence:
+    def test_filters_per_result(self):
+        results = [
+            {"tool": "a", "findings": [{"confidence": 0.9}, {"confidence": 0.2}]},
+            {"tool": "b", "findings": [{"confidence": 0.6}, {"confidence": 0.1}]},
+        ]
+        out = filter_results_by_confidence(results, 0.5)
+        assert [len(r["findings"]) for r in out] == [1, 1]
+        assert out[0]["findings"][0]["confidence"] == 0.9
+        assert out[1]["findings"][0]["confidence"] == 0.6
+
+    def test_keeps_unscored_findings(self):
+        results = [{"tool": "a", "findings": [{"type": "x"}, {"confidence": 0.1}]}]
+        out = filter_results_by_confidence(results, 0.5)
+        # The unscored finding defaults to 1.0 and is kept; the low one is dropped.
+        assert len(out[0]["findings"]) == 1
+        assert out[0]["findings"][0]["type"] == "x"
+
+    def test_noop_at_zero(self):
+        results = [{"tool": "a", "findings": [{"confidence": 0.1}, {"confidence": 0.9}]}]
+        out = filter_results_by_confidence(results, 0.0)
+        assert [f["confidence"] for f in out[0]["findings"]] == [0.1, 0.9]
+
+    def test_does_not_mutate_inputs(self):
+        low = {"confidence": 0.1}
+        results = [{"tool": "a", "findings": [{"confidence": 0.9}, low]}]
+        out = filter_results_by_confidence(results, 0.5)
+        # Input list, dict, and its findings list are untouched.
+        assert len(results[0]["findings"]) == 2
+        assert low in results[0]["findings"]
+        # Output holds fresh result dicts and finding lists.
+        assert out[0] is not results[0]
+        assert out[0]["findings"] is not results[0]["findings"]
+
+
+# ===========================================================================
+# CLI: scan --ci --fail-on-confidence
+# ===========================================================================
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _run_scan(runner, tmp_path, *, confidence: float, extra_args: list[str]):
+    """Invoke `miesc scan` on a one-file project with a single CRITICAL finding
+    carrying the given confidence. All analysis collaborators are mocked so the
+    injected confidence survives to the gate untouched."""
+    contract = tmp_path / "C.sol"
+    contract.write_text("pragma solidity ^0.8.0; contract C {}")
+
+    finding = {
+        "type": "reentrancy",
+        "title": "Reentrancy in withdraw",
+        "severity": "CRITICAL",
+        "message": "state updated after external call",
+        "confidence": confidence,
+        "location": {"file": str(contract), "line": 1},
+    }
+
+    def fake_run(tool, *a, **k):
+        if tool == "slither":
+            return {"tool": "slither", "status": "success", "findings": [finding]}
+        return {"tool": tool, "status": "success", "findings": []}
+
+    with (
+        patch(f"{SCAN}.run_tool", side_effect=fake_run),
+        # Keep findings as-is through the intelligence engine.
+        patch("miesc.core.intelligence.enhance_findings", side_effect=lambda f, **k: f),
+        # Do NOT recompute confidence — preserve the injected score.
+        patch("miesc.core.confidence.annotate_confidence", lambda *a, **k: None),
+    ):
+        return runner.invoke(
+            scan,
+            [str(contract), "--fp-strictness", "off", *extra_args],
+        )
+
+
+def test_low_confidence_critical_does_not_trip_ci(runner, tmp_path):
+    out = tmp_path / "r.json"
+    result = _run_scan(
+        runner,
+        tmp_path,
+        confidence=0.2,
+        extra_args=["--ci", "--fail-on-confidence", "0.5", "-o", str(out)],
+    )
+    # Below the gate threshold -> CI must NOT fail.
+    assert result.exit_code == 0, result.output
+    # ...but the finding is still reported in full (not hidden).
+    data = json.loads(out.read_text())
+    criticals = [f for f in data["findings"] if f.get("severity") == "CRITICAL"]
+    assert len(criticals) == 1
+    assert data["summary"]["CRITICAL"] == 1
+
+
+def test_high_confidence_critical_trips_ci(runner, tmp_path):
+    result = _run_scan(
+        runner,
+        tmp_path,
+        confidence=0.9,
+        extra_args=["--ci", "--fail-on-confidence", "0.5"],
+    )
+    # At/above the gate threshold -> CI must fail.
+    assert result.exit_code == 1, result.output


### PR DESCRIPTION
Completes the confidence story from #83 by making it actionable in CI.

## Complementary to `--min-confidence`
- `--min-confidence` (shipped in #83) **hides** low-confidence findings from the report.
- `--fail-on-confidence` (this PR) **hides nothing** — it only changes the **exit code**: the `--ci`/`--fail-on` gate trips solely on findings whose calibrated confidence meets the threshold. Teams see every finding but block the build only on the ones MIESC is confident about → fewer false-alarm CI failures, the real pain of adopting a security tool in CI.

## How
- New `confidence.filter_results_by_confidence(results, min_confidence)` returns a confidence-filtered *view* of the results for the gate summary, **without mutating** the reported/saved findings.
- `audit full`'s three sub-paths are centralized into one `_apply_ci_gate()` helper (removes duplication); `scan` computes a separate gate summary. The displayed summary and JSON/SARIF output still reflect **all** findings.
- `--fail-on-confidence FLOAT` (default 0.0 = gate on everything, unchanged behavior) on `scan` and `audit full`.

## Tests / safety
6 new tests (helper units + CLI: a CRITICAL @ confidence 0.2 does NOT trip `--ci --fail-on-confidence 0.5` and is still reported; a CRITICAL @ 0.9 does). **1138 audit/scan/ci-gate/baseline/rank tests pass** — the gate refactor is behavior-preserving. ruff + black clean. Sequencing merge on green CI (touches audit/scan gate plumbing).

Note: the implementation was drafted by a subagent that hit an API error before committing; I reviewed the full diff (confirmed no double-gating: the untouched inline gates live in `audit_quick`/`audit_profile`, out of scope), verified the gate uses the confidence-filtered summary while output is untouched, ran the suites, and finished it.