### PR TITLE
feat(action): expose min-confidence input for CI confidence filtering

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Fail the action on findings of this severity or higher: critical, high, medium, low, none'
     required: false
     default: 'high'
+  min-confidence:
+    description: 'Drop findings whose calibrated confidence is below this threshold (0.0-1.0) before reporting and gating. Confidence blends detector reliability, cross-tool agreement and the false-positive signal. Default 0 keeps everything. Applies to scan and audit-full.'
+    required: false
+    default: '0'
   timeout:
     description: 'Timeout per tool in seconds'
     required: false
@@ -155,6 +159,13 @@ runs:
           SKIP_FLAG="--skip-unavailable"
         fi
 
+        # Confidence filter (scan / audit-full only): drop low-confidence noise
+        # before reporting and gating. Skipped when unset or zero.
+        CONF_FLAG=""
+        if [ -n "${{ inputs.min-confidence }}" ] && [ "${{ inputs.min-confidence }}" != "0" ] && [ "${{ inputs.min-confidence }}" != "0.0" ]; then
+          CONF_FLAG="--min-confidence ${{ inputs.min-confidence }}"
+        fi
+
         if [ "$FORMAT" = "sarif" ]; then
           OUTPUT_EXT="sarif"
         elif [ "$FORMAT" = "markdown" ]; then
@@ -183,7 +194,7 @@ runs:
             if [ -n "$NOTIFY_FLAGS" ]; then
               NOTIFY_FLAGS="$NOTIFY_FLAGS --notify-min-severity ${{ inputs.notify-min-severity }}"
             fi
-            miesc scan "$PATH_INPUT" -o "$RESULTS_JSON" --ci $NOTIFY_FLAGS 2>&1
+            miesc scan "$PATH_INPUT" -o "$RESULTS_JSON" --ci $CONF_FLAG $NOTIFY_FLAGS 2>&1
             MIESC_EXIT=$?
             ;;
           audit-quick)
@@ -191,7 +202,7 @@ runs:
             MIESC_EXIT=$?
             ;;
           audit-full)
-            miesc audit full "$PATH_INPUT" -o "$RESULTS_JSON" -t "$TIMEOUT" $SKIP_FLAG 2>&1
+            miesc audit full "$PATH_INPUT" -o "$RESULTS_JSON" -t "$TIMEOUT" $SKIP_FLAG $CONF_FLAG 2>&1
             MIESC_EXIT=$?
             ;;
           audit-layer)


### PR DESCRIPTION
Makes the calibrated confidence (CLI: #83/#90) usable on the GitHub Action — its primary CI surface. New **`min-confidence`** input (default `0` = keep everything) is threaded as `--min-confidence` into the `scan` and `audit-full` invocations.

## Why here
The action gates on **severity counts** parsed from the results, so filtering low-confidence findings via `--min-confidence` both cleans the GitHub Security tab and makes the severity gate confidence-aware (fewer false-alarm CI failures) in one knob. Only wired to `scan`/`audit-full` (the modes whose CLI supports the flag); quick/layer/profile untouched.

```yaml
- uses: fboiero/MIESC@v6
  with:
    mode: audit-full
    min-confidence: '0.5'   # only surface/gate on findings MIESC is confident about
```

action.yml YAML validated; CONF_FLAG guarded (unset/zero → no flag). No frozen artifacts touched.