### PR TITLE
feat: miesc score — composite security score + badge

### DIFF
--- a/miesc/cli/commands/score.py
+++ b/miesc/cli/commands/score.py
@@ -1,0 +1,269 @@
+"""
+MIESC CLI - Score Command
+
+Turn a scan/audit's findings into a single composite security score (0-100 and an
+A-F grade) plus an optional shields.io-style badge, so a project can display and
+CI-gate its security posture at a glance.
+
+Author: Fernando Boiero
+License: AGPL-3.0
+"""
+
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import click
+
+from miesc.cli.utils import (
+    RICH_AVAILABLE,
+    console,
+    error,
+    info,
+    success,
+)
+from miesc.core.confidence import filter_by_min_confidence
+from miesc.core.scoring import (
+    SecurityScore,
+    badge_endpoint,
+    badge_svg,
+    compute_score,
+    extract_findings,
+)
+
+# =============================================================================
+# Score Command
+# =============================================================================
+
+
+@click.command()
+@click.argument("input_path", type=click.Path(exists=True), default=".")
+@click.option(
+    "--badge",
+    type=click.Choice(["svg", "json", "markdown"]),
+    default=None,
+    help="Emit a badge instead of the human summary: svg=self-contained SVG, "
+    "json=shields.io endpoint JSON, markdown=an embeddable ![...] snippet.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    help="Write the badge (with --badge) or the JSON score result to this file.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Print the machine-readable score result (JSON) to stdout.",
+)
+@click.option(
+    "--fail-under",
+    type=int,
+    default=0,
+    help="CI gate: exit 1 if the computed score is below this value (default 0, never fails).",
+)
+@click.option(
+    "--min-confidence",
+    "min_confidence",
+    type=float,
+    default=0.0,
+    help="Drop findings whose calibrated confidence is below this threshold (0.0-1.0) "
+    "before scoring, so low-confidence noise does not drag the score down. Findings "
+    "without a confidence score are always kept. Default 0.0 keeps everything.",
+)
+def score(
+    input_path: str,
+    badge: str | None,
+    output: str | None,
+    as_json: bool,
+    fail_under: int,
+    min_confidence: float,
+) -> None:
+    """Composite security score (0-100 / A-F) and badge for a scan's findings.
+
+    INPUT_PATH may be:
+
+    \b
+      - a MIESC results JSON (from 'miesc scan -o report.json'): scored directly;
+      - a .sol file or a directory: scanned first, then scored.
+
+    \b
+    Examples:
+      miesc score report.json
+      miesc score report.json --json
+      miesc score report.json --badge svg -o security.svg
+      miesc score report.json --badge markdown
+      miesc score contracts/ --fail-under 70          # CI gate
+      miesc score report.json --min-confidence 0.4     # drop low-confidence noise
+    """
+    results = _load_results(input_path)
+    findings = extract_findings(results)
+
+    if min_confidence and min_confidence > 0.0:
+        findings, dropped = filter_by_min_confidence(findings, min_confidence)
+        if dropped and not as_json and badge is None:
+            info(f"min-confidence {min_confidence}: dropped {dropped} low-confidence finding(s)")
+
+    result = compute_score(findings)
+
+    # ------------------------------------------------------------------ badge
+    if badge is not None:
+        payload = _render_badge(badge, result)
+        if output:
+            Path(output).write_text(payload, encoding="utf-8")
+            success(f"Badge written to {output}")
+        else:
+            click.echo(payload)
+        _apply_gate(result, fail_under)
+        return
+
+    # -------------------------------------------------------------- JSON result
+    if as_json:
+        payload = json.dumps(result.to_dict(), indent=2)
+        if output:
+            Path(output).write_text(payload + "\n", encoding="utf-8")
+        click.echo(payload)
+        _apply_gate(result, fail_under)
+        return
+
+    # ---------------------------------------------------------- human summary
+    _print_human(result)
+    if output:
+        Path(output).write_text(json.dumps(result.to_dict(), indent=2) + "\n", encoding="utf-8")
+        success(f"Score written to {output}")
+
+    _apply_gate(result, fail_under)
+
+
+# =============================================================================
+# Private helpers
+# =============================================================================
+
+
+def _load_results(input_path: str) -> list[dict[str, Any]]:
+    """Resolve INPUT_PATH to a MIESC results structure (list of per-tool dicts).
+
+    A ``.json`` file (or any file that parses as JSON) is loaded directly. A
+    ``.sol`` file or a directory is scanned first via ``miesc scan -o <tmp>.json``
+    and the resulting report is loaded. JSON input is the must-have path; scanning
+    is the convenience path.
+    """
+    path = Path(input_path)
+
+    if path.is_file():
+        data = _try_load_json(path)
+        if data is not None:
+            return _results_from_data(data)
+
+    # .sol file or directory -> scan into a temp report, then load it.
+    return _scan_to_results(input_path)
+
+
+def _try_load_json(path: Path) -> Any | None:
+    """Return parsed JSON if ``path`` is a JSON document, else ``None``."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, OSError):
+        return None
+
+
+def _results_from_data(data: Any) -> list[dict[str, Any]]:
+    """Mirror the export command's result extraction: ``data.get('results', [data])``."""
+    if isinstance(data, dict):
+        return data.get("results", [data])
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def _scan_to_results(input_path: str) -> list[dict[str, Any]]:
+    """Run ``miesc scan <input_path> -o <tmp>.json --quiet`` and load the report."""
+    info(f"Scanning {input_path} to compute a score...")
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        tmp_path = tmp.name
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "miesc.cli.main",
+                "scan",
+                input_path,
+                "-o",
+                tmp_path,
+                "--quiet",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        data = _try_load_json(Path(tmp_path))
+        if data is None:
+            error(
+                "Scan did not produce a readable report "
+                f"(exit {proc.returncode}). {proc.stderr.strip()[:200]}"
+            )
+            raise click.Abort()
+        return _results_from_data(data)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def _render_badge(kind: str, result: SecurityScore) -> str:
+    """Render the requested badge representation as a string."""
+    if kind == "svg":
+        return badge_svg(result)
+    if kind == "json":
+        return json.dumps(badge_endpoint(result), indent=2)
+    # markdown: an embeddable snippet with the SVG inlined as a self-contained data URI.
+    svg_b64 = base64.b64encode(badge_svg(result).encode("utf-8")).decode("ascii")
+    return f"![MIESC security](data:image/svg+xml;base64,{svg_b64})"
+
+
+def _severity_line(result: SecurityScore) -> str:
+    """One-line severity breakdown, e.g. '0 critical · 1 high · 3 medium · 0 low'."""
+    counts = result.severity_counts
+    always = ["critical", "high", "medium", "low"]
+    parts = [f"{counts.get(sev, 0)} {sev}" for sev in always]
+    # Append any other severities actually present (e.g. "info", "optimization").
+    for sev, count in counts.items():
+        if sev not in always:
+            parts.append(f"{count} {sev}")
+    return " · ".join(parts)
+
+
+def _print_human(result: SecurityScore) -> None:
+    """Print the score, grade and severity breakdown for a human reader."""
+    sev_line = _severity_line(result)
+    if RICH_AVAILABLE:
+        grade_color = {
+            "A": "green",
+            "B": "green",
+            "C": "yellow",
+            "D": "red",
+            "F": "red",
+        }.get(result.grade, "white")
+        console.print(
+            f"[bold]MIESC Security Score:[/bold] "
+            f"[bold {grade_color}]{result.score}/100[/bold {grade_color}]  ({result.grade})"
+        )
+        console.print(f"[dim]{sev_line}[/dim]")
+        if result.weighted_by_confidence:
+            console.print("[dim]score weighted by per-finding confidence[/dim]")
+    else:
+        print(f"MIESC Security Score: {result.score}/100  ({result.grade})")  # noqa: T201
+        print(sev_line)  # noqa: T201
+        if result.weighted_by_confidence:
+            print("score weighted by per-finding confidence")  # noqa: T201
+
+
+def _apply_gate(result: SecurityScore, fail_under: int) -> None:
+    """CI gate: exit 1 when the score is below ``fail_under``."""
+    if fail_under and result.score < fail_under:
+        error(f"Security score {result.score} is below the required {fail_under} (--fail-under).")
+        sys.exit(1)

--- a/miesc/cli/main.py
+++ b/miesc/cli/main.py
@@ -48,6 +48,7 @@ from miesc.cli.commands.poc import poc as poc_group  # noqa: E402
 from miesc.cli.commands.remediate import remediate as remediate_cmd  # noqa: E402
 from miesc.cli.commands.report import report as report_cmd  # noqa: E402
 from miesc.cli.commands.scan import scan as scan_cmd  # noqa: E402
+from miesc.cli.commands.score import score as score_cmd  # noqa: E402
 from miesc.cli.commands.server import server as server_group  # noqa: E402
 from miesc.cli.commands.specs import specs as specs_cmd  # noqa: E402
 from miesc.cli.commands.testgen import testgen as testgen_cmd  # noqa: E402
@@ -130,6 +131,7 @@ cli.add_command(poc_group, name="poc")
 cli.add_command(remediate_cmd, name="remediate")
 cli.add_command(report_cmd, name="report")
 cli.add_command(scan_cmd, name="scan")
+cli.add_command(score_cmd, name="score")
 cli.add_command(server_group, name="server")
 cli.add_command(specs_cmd, name="specs")
 cli.add_command(testgen_cmd, name="test-gen")

--- a/miesc/core/scoring.py
+++ b/miesc/core/scoring.py
@@ -1,0 +1,164 @@
+"""Composite security score + badge for a set of findings.
+
+Turns a scan/audit's findings into a single 0-100 score (and an A-F grade) by
+penalizing each finding by its severity weight scaled by its calibrated
+confidence — so a confident critical hurts far more than an uncertain
+informational note, and low-confidence noise barely moves the number. A clean
+contract scores 100 (A); the penalty saturates the score at 0.
+
+The score is deliberately simple and interpretable (a transparent weighted
+penalty, not a black box) so a project can reason about why it got the grade it
+did. Confidence weighting reuses the calibrated ``confidence`` already attached to
+findings; findings without one are treated as fully confident (weight 1.0).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence, Tuple
+
+# Points off a perfect 100 per finding, before confidence scaling. Tuned so a
+# single high-confidence critical fails the grade while low/info barely register.
+SEVERITY_PENALTY: Dict[str, float] = {
+    "critical": 40.0,
+    "high": 15.0,
+    "medium": 5.0,
+    "low": 1.5,
+    "info": 0.3,
+    "informational": 0.3,
+    "optimization": 0.1,
+    "note": 0.3,
+}
+_DEFAULT_PENALTY = 5.0  # unknown severity ~ medium
+
+# score >= threshold -> grade (checked high to low)
+_GRADES: List[Tuple[int, str]] = [(90, "A"), (80, "B"), (70, "C"), (60, "D"), (0, "F")]
+
+# grade -> badge colour (GitHub-ish palette)
+GRADE_COLORS: Dict[str, str] = {
+    "A": "#2ea043",
+    "B": "#7cb342",
+    "C": "#c9b458",
+    "D": "#e08e0b",
+    "F": "#d73a49",
+}
+
+
+@dataclass
+class SecurityScore:
+    """A composite security score for one analysis."""
+
+    score: int  # 0-100, higher is safer
+    grade: str  # A-F
+    total_findings: int
+    severity_counts: Dict[str, int] = field(default_factory=dict)
+    penalty: float = 0.0  # total penalty subtracted from 100
+    weighted_by_confidence: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "score": self.score,
+            "grade": self.grade,
+            "total_findings": self.total_findings,
+            "severity_counts": self.severity_counts,
+            "penalty": self.penalty,
+            "weighted_by_confidence": self.weighted_by_confidence,
+        }
+
+
+def _grade(score: int) -> str:
+    for threshold, g in _GRADES:
+        if score >= threshold:
+            return g
+    return "F"
+
+
+def _confidence_weight(finding: Dict[str, Any]) -> Tuple[float, bool]:
+    conf = finding.get("confidence")
+    if conf is None:
+        return 1.0, False
+    try:
+        return max(0.0, min(1.0, float(conf))), True
+    except (TypeError, ValueError):
+        return 1.0, False
+
+
+def compute_score(findings: Sequence[Dict[str, Any]]) -> SecurityScore:
+    """Compute the composite score from findings (each a dict with ``severity``
+    and optionally ``confidence``)."""
+    penalty = 0.0
+    counts: Dict[str, int] = {}
+    weighted = False
+    for f in findings:
+        sev = str(f.get("severity", "info")).strip().lower()
+        counts[sev] = counts.get(sev, 0) + 1
+        base = SEVERITY_PENALTY.get(sev, _DEFAULT_PENALTY)
+        weight, was_weighted = _confidence_weight(f)
+        weighted = weighted or was_weighted
+        penalty += base * weight
+    score = max(0, min(100, round(100 - penalty)))
+    return SecurityScore(
+        score=score,
+        grade=_grade(score),
+        total_findings=len(findings),
+        severity_counts=counts,
+        penalty=round(penalty, 1),
+        weighted_by_confidence=weighted,
+    )
+
+
+def extract_findings(results: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Flatten a results structure (list of per-tool dicts each with ``findings``)
+    into a single findings list."""
+    findings: List[Dict[str, Any]] = []
+    for result in results:
+        findings.extend(result.get("findings", []) or [])
+    return findings
+
+
+def badge_endpoint(score: SecurityScore) -> Dict[str, Any]:
+    """shields.io endpoint schema, so a project can render the badge remotely."""
+    return {
+        "schemaVersion": 1,
+        "label": "MIESC security",
+        "message": f"{score.score} {score.grade}",
+        "color": GRADE_COLORS.get(score.grade, "#9f9f9f"),
+    }
+
+
+def badge_svg(score: SecurityScore) -> str:
+    """A self-contained shields.io-style SVG (no external requests), so it can be
+    committed and embedded directly: ``[ MIESC security | 82 A ]``."""
+    label = "MIESC security"
+    message = f"{score.score} {score.grade}"
+    color = GRADE_COLORS.get(score.grade, "#9f9f9f")
+    # ~6.5px per char + 10px padding each side; good enough without font metrics.
+    lw = int(len(label) * 6.5) + 20
+    mw = int(len(message) * 6.5) + 20
+    total = lw + mw
+    lx = lw * 10 // 2
+    mx = (lw + mw // 2) * 10
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" '
+        f'role="img" aria-label="{label}: {message}">'
+        f"<title>{label}: {message}</title>"
+        f'<linearGradient id="s" x2="0" y2="100%">'
+        f'<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>'
+        f'<stop offset="1" stop-opacity=".1"/></linearGradient>'
+        f'<clipPath id="r"><rect width="{total}" height="20" rx="3" fill="#fff"/></clipPath>'
+        f'<g clip-path="url(#r)">'
+        f'<rect width="{lw}" height="20" fill="#555"/>'
+        f'<rect x="{lw}" width="{mw}" height="20" fill="{color}"/>'
+        f'<rect width="{total}" height="20" fill="url(#s)"/></g>'
+        f'<g fill="#fff" text-anchor="middle" '
+        f'font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110">'
+        f'<text x="{lx}" y="150" fill="#010101" fill-opacity=".3" '
+        f'transform="scale(.1)" textLength="{(lw - 20) * 10}">{label}</text>'
+        f'<text x="{lx}" y="140" transform="scale(.1)" '
+        f'textLength="{(lw - 20) * 10}">{label}</text>'
+        f'<text x="{mx}" y="150" fill="#010101" fill-opacity=".3" '
+        f'transform="scale(.1)" textLength="{(mw - 20) * 10}">{message}</text>'
+        f'<text x="{mx}" y="140" transform="scale(.1)" '
+        f'textLength="{(mw - 20) * 10}">{message}</text>'
+        f"</g></svg>"
+    )

--- a/tests/test_score_command.py
+++ b/tests/test_score_command.py
@@ -1,0 +1,129 @@
+"""Tests for the ``miesc score`` CLI command.
+
+The command turns a scan/audit's findings into a composite security score plus an
+optional badge. These tests pin the JSON-input path (the must-have), the badge
+emission, the CI ``--fail-under`` gate, and the ``--min-confidence`` pre-filter,
+cross-checking each against ``compute_score`` on the same findings so the CLI can
+never silently drift from the scoring core.
+
+Author: Fernando Boiero
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from miesc.cli.commands.score import score
+from miesc.core.scoring import compute_score
+
+# A results JSON with a mix of severities and confidences, in the per-tool shape
+# the scan/export commands emit (a list of dicts each with a "findings" list).
+_FINDINGS = [
+    {"severity": "high", "confidence": 0.9},
+    {"severity": "medium", "confidence": 0.8},
+    {"severity": "medium", "confidence": 0.7},
+    {"severity": "critical", "confidence": 0.2},  # low-confidence noise
+]
+
+
+def _write_report(tmp_path: Path) -> str:
+    report = {
+        "contract": "Foo.sol",
+        "results": [
+            {"tool": "slither", "findings": _FINDINGS[:2]},
+            {"tool": "mythril", "findings": _FINDINGS[2:]},
+        ],
+    }
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    return str(path)
+
+
+def test_scores_a_results_json(tmp_path):
+    expected = compute_score(_FINDINGS)
+    runner = CliRunner()
+    result = runner.invoke(score, [_write_report(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert f"{expected.score}/100" in result.output
+    assert f"({expected.grade})" in result.output
+
+
+def test_json_flag_emits_machine_readable(tmp_path):
+    expected = compute_score(_FINDINGS)
+    runner = CliRunner()
+    result = runner.invoke(score, [_write_report(tmp_path), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["score"] == expected.score
+    assert payload["grade"] == expected.grade
+    assert payload["total_findings"] == len(_FINDINGS)
+
+
+def test_badge_svg_written_to_file(tmp_path):
+    out = tmp_path / "badge.svg"
+    runner = CliRunner()
+    result = runner.invoke(score, [_write_report(tmp_path), "--badge", "svg", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    content = out.read_text(encoding="utf-8")
+    assert content.startswith("<svg")
+    assert content.rstrip().endswith("</svg>")
+
+
+def test_badge_json_is_shields_endpoint(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(score, [_write_report(tmp_path), "--badge", "json"])
+    assert result.exit_code == 0, result.output
+    endpoint = json.loads(result.output)
+    assert endpoint["schemaVersion"] == 1
+    assert endpoint["label"] == "MIESC security"
+
+
+def test_badge_markdown_is_self_contained(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(score, [_write_report(tmp_path), "--badge", "markdown"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip().startswith("![MIESC security](data:image/svg+xml;base64,")
+
+
+def test_fail_under_above_score_exits_nonzero(tmp_path):
+    expected = compute_score(_FINDINGS)
+    runner = CliRunner()
+    result = runner.invoke(
+        score, [_write_report(tmp_path), "--fail-under", str(expected.score + 1)]
+    )
+    assert result.exit_code == 1
+    assert "below" in result.output.lower()
+
+
+def test_fail_under_below_score_exits_zero(tmp_path):
+    expected = compute_score(_FINDINGS)
+    runner = CliRunner()
+    result = runner.invoke(
+        score, [_write_report(tmp_path), "--fail-under", str(max(expected.score - 1, 0))]
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_min_confidence_filters_low_confidence_findings(tmp_path):
+    """Filtering low-confidence noise should raise the score (fewer penalties)."""
+    report_path = _write_report(tmp_path)
+    runner = CliRunner()
+
+    baseline = runner.invoke(score, [report_path, "--json"])
+    filtered = runner.invoke(score, [report_path, "--json", "--min-confidence", "0.5"])
+    assert baseline.exit_code == 0, baseline.output
+    assert filtered.exit_code == 0, filtered.output
+
+    baseline_score = json.loads(baseline.output)["score"]
+    filtered_score = json.loads(filtered.output)["score"]
+    assert filtered_score > baseline_score
+
+    # Cross-check: the filtered score matches compute_score over the kept findings
+    # (everything with confidence >= 0.5).
+    kept = [f for f in _FINDINGS if f["confidence"] >= 0.5]
+    assert filtered_score == compute_score(kept).score

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,116 @@
+"""Unit tests for the composite security score + badge.
+
+Pin the invariants that make the score meaningful and stable: a clean contract is
+100/A, severity and confidence both move the number in the right direction, the
+score never leaves [0, 100], and the badge is well-formed self-contained SVG.
+"""
+
+import unittest
+
+from miesc.core.scoring import (
+    SEVERITY_PENALTY,
+    badge_endpoint,
+    badge_svg,
+    compute_score,
+    extract_findings,
+)
+
+
+def _f(severity, confidence=None):
+    d = {"severity": severity}
+    if confidence is not None:
+        d["confidence"] = confidence
+    return d
+
+
+class TestComputeScore(unittest.TestCase):
+    def test_clean_contract_is_perfect(self):
+        s = compute_score([])
+        self.assertEqual(s.score, 100)
+        self.assertEqual(s.grade, "A")
+        self.assertEqual(s.total_findings, 0)
+
+    def test_confident_critical_fails_the_grade(self):
+        s = compute_score([_f("critical", 1.0)])
+        self.assertLess(s.score, 70)
+        self.assertIn(s.grade, ("D", "F"))
+
+    def test_confidence_softens_the_penalty(self):
+        confident = compute_score([_f("critical", 1.0)]).score
+        unsure = compute_score([_f("critical", 0.2)]).score
+        self.assertGreater(unsure, confident, "a low-confidence critical hurts less")
+
+    def test_more_severe_hurts_more(self):
+        high = compute_score([_f("high", 1.0)]).score
+        low = compute_score([_f("low", 1.0)]).score
+        self.assertLess(high, low)
+
+    def test_score_is_bounded_below_at_zero(self):
+        s = compute_score([_f("critical", 1.0) for _ in range(50)])
+        self.assertEqual(s.score, 0)
+        self.assertEqual(s.grade, "F")
+
+    def test_unscored_findings_treated_as_confident(self):
+        s = compute_score([_f("high")])  # no confidence key
+        self.assertFalse(s.weighted_by_confidence)
+        self.assertEqual(s.penalty, SEVERITY_PENALTY["high"])
+
+    def test_weighted_flag_set_when_confidence_present(self):
+        s = compute_score([_f("high", 0.5)])
+        self.assertTrue(s.weighted_by_confidence)
+
+    def test_severity_counts_and_unknown_severity(self):
+        s = compute_score([_f("high", 1.0), _f("high", 1.0), _f("weird", 1.0)])
+        self.assertEqual(s.severity_counts["high"], 2)
+        self.assertEqual(s.severity_counts["weird"], 1)
+
+    def test_grade_boundaries(self):
+        self.assertEqual(compute_score([]).grade, "A")  # 100
+        # a single medium (5 pts) -> 95 -> still A
+        self.assertEqual(compute_score([_f("medium", 1.0)]).grade, "A")
+
+    def test_bad_confidence_value_falls_back(self):
+        s = compute_score([{"severity": "high", "confidence": "oops"}])
+        self.assertEqual(s.penalty, SEVERITY_PENALTY["high"])
+
+
+class TestExtractFindings(unittest.TestCase):
+    def test_flattens_results(self):
+        results = [
+            {"tool": "slither", "findings": [_f("high"), _f("low")]},
+            {"tool": "mythril", "findings": [_f("critical")]},
+            {"tool": "empty", "findings": []},
+        ]
+        self.assertEqual(len(extract_findings(results)), 3)
+
+    def test_missing_findings_key(self):
+        self.assertEqual(extract_findings([{"tool": "x"}]), [])
+
+
+class TestBadge(unittest.TestCase):
+    def test_endpoint_schema(self):
+        s = compute_score([_f("high", 0.9)])
+        b = badge_endpoint(s)
+        self.assertEqual(b["schemaVersion"], 1)
+        self.assertEqual(b["label"], "MIESC security")
+        self.assertTrue(b["message"].startswith(str(s.score)))
+        self.assertTrue(b["color"].startswith("#"))
+
+    def test_svg_is_wellformed_and_self_contained(self):
+        s = compute_score([_f("medium", 0.5)])
+        svg = badge_svg(s)
+        self.assertTrue(svg.startswith("<svg"))
+        self.assertTrue(svg.rstrip().endswith("</svg>"))
+        self.assertIn("MIESC security", svg)
+        self.assertIn(f"{s.score} {s.grade}", svg)
+        self.assertNotIn("http://", svg.replace("http://www.w3.org", ""))  # no external refs
+
+    def test_to_dict_roundtrip(self):
+        s = compute_score([_f("high", 0.9)])
+        d = s.to_dict()
+        self.assertEqual(d["score"], s.score)
+        self.assertEqual(d["grade"], s.grade)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A new `miesc score` command that turns findings into a single **security score (0-100) + letter grade (A-F)** and a shareable **badge** — the kind of at-a-glance signal OSS projects want (like a coverage badge), and it reuses the calibrated confidence from #83.

## Model (transparent, not a black box)
Each finding subtracts a per-severity penalty **scaled by its calibrated confidence**, so a confident critical fails the grade while low-confidence noise barely moves it. Clean contract = 100/A; penalty saturates at 0. Rubric lives in `miesc/core/scoring.py` and is fully documented.

## Command
```
$ miesc score ./contracts            # scans (subprocess) then scores
$ miesc score results.json           # scores an existing scan/audit JSON (composable)
  MIESC Security Score: 84/100  (B)
  0 critical · 1 high · 1 medium   (confidence-weighted)
$ miesc score results.json --badge svg -o badge.svg    # self-contained SVG for the README
$ miesc score results.json --fail-under 80             # CI gate: exit 1 if score < 80
```
Options: `--badge [svg|json|markdown]` (svg = self-contained no-external-requests SVG; json = shields.io endpoint; markdown = inline data-URI snippet), `-o/--output`, `--json`, `--fail-under N`, `--min-confidence`.

## Tests / safety
23 tests (15 scoring-core invariants: clean=100/A, severity+confidence move it correctly, bounded [0,100], badge well-formed & self-contained; 8 CLI: JSON+path input, --json, --badge svg, --fail-under exit codes, --min-confidence). ruff+black clean. Pure-core, no external deps, no frozen artifacts touched. Sequencing merge on green CI.

Implementation split: I built + tested the scoring core; a subagent built the CLI wiring, which I then independently verified end-to-end (score math, --json, --fail-under exit codes, badge).