### PR TITLE
docs: document confidence calibration, CI gates and miesc score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Calibrated finding confidence.** Every finding now carries a `confidence`
+  (0-1) and `confidence_level` (high/medium/low), blending detector reliability
+  (reused from the correlation engine's tool weights), cross-tool agreement, and
+  the false-positive signal. `scan` and `audit full` gain `--min-confidence FLOAT`
+  to drop low-confidence noise, and the SARIF export fills the `rank` slot from the
+  calibrated confidence for triage in GitHub Code Scanning.
+- **Confidence-aware CI gate.** `--fail-on-confidence FLOAT` on `scan` and
+  `audit full` trips the `--ci`/`--fail-on` gate only on findings whose confidence
+  meets the threshold. The report still shows every finding — only the exit code
+  changes — so a noisy first run does not block the build on low-confidence issues.
+- **`min-confidence` GitHub Action input**, threaded into the `scan` and
+  `audit-full` runs so the confidence filter is available in CI, not just locally.
+- **`miesc score`** — a composite security score (0-100) and letter grade (A-F)
+  that weights findings by severity × calibrated confidence, plus a shareable badge
+  (`--badge svg|json|markdown`; the SVG is self-contained). Scores a contract path
+  or an existing scan/audit report; `--fail-under N` gates CI on the score.
+
 ## [6.0.0] - 2026-07-12
 
 MIESC v6.0 turns the analyzer into something a team can adopt in CI without a

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -75,6 +75,29 @@ miesc audit batch ./contracts/ -r -o report.json
 miesc audit batch ./contracts/ -j 4 -o report.json
 ```
 
+### Confidence & Security Score
+
+Every finding carries a **calibrated confidence** (0-1) blending detector
+reliability, cross-tool agreement, and the false-positive signal — so you can
+rank and filter by how much a finding is worth trusting.
+
+```bash
+# Drop low-confidence noise from the report
+miesc scan MyContract.sol --min-confidence 0.5
+
+# CI gate that fails ONLY on findings MIESC is confident about
+# (the report still shows everything; only the exit code changes)
+miesc scan MyContract.sol --ci --fail-on-confidence 0.7
+
+# A single security score (0-100) + grade (A-F), weighted by severity x confidence
+miesc score MyContract.sol
+miesc score full_audit.json                    # score an existing report
+
+# A shareable badge for your README, and a CI gate on the score
+miesc score full_audit.json --badge svg -o security-badge.svg
+miesc score full_audit.json --fail-under 80
+```
+
 ## 4. The 9 Defense Layers
 
 MIESC analyzes contracts through **9 specialized defense layers**:


### PR DESCRIPTION
This arc shipped four user-facing capabilities with **no user-facing docs** — a feature you can't discover is half-shipped. This adds them.

## What
- **CHANGELOG `[Unreleased]`** — entries for calibrated confidence + `--min-confidence`, the `--fail-on-confidence` CI gate, the action `min-confidence` input, and `miesc score` + badge.
- **`docs/guides/QUICKSTART.md`** — a new *Confidence & Security Score* section with copy-paste examples (filter noise, confidence-aware CI gate, score + badge + `--fail-under`).

## Scope / safety
Docs only, no code. **README is frozen** (tracked by the reproducibility manifest) so it is deliberately left untouched — the quickstart guide and CHANGELOG are the non-frozen homes for this. Both edited files verified not-frozen. Markdown structure intact.