### PR TITLE
feat(formal): structured counterexample assignments (phase 1 of counterexample→PoC)

### DIFF
--- a/miesc/formal/unified_report.py
+++ b/miesc/formal/unified_report.py
@@ -64,6 +64,22 @@ def normalize_status(raw_status: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def parse_assignments(text: str) -> List[Dict[str, str]]:
+    """Extract ``name = value`` bindings from a counterexample witness.
+
+    Handles both the single-line comma-separated form Halmos/Kontrol print
+    (``amount = 3, to = 0x0``) and the indented multi-line form SMTChecker/solc-mc
+    print. Each value keeps its raw representation (decimal, ``2**256 - 1``,
+    ``0x...``). Returns ``[{"name": ..., "value": ...}, ...]`` in first-seen order.
+    Best-effort: the raw ``text`` is always preserved separately, so a parse miss
+    loses nothing. This structured form is what a PoC generator consumes.
+    """
+    assignments: List[Dict[str, str]] = []
+    for match in re.finditer(r"([A-Za-z_]\w*)\s*=\s*([^,\n]+)", text):
+        assignments.append({"name": match.group(1).strip(), "value": match.group(2).strip()})
+    return assignments
+
+
 @dataclass
 class Counterexample:
     """A single counterexample / violation witness attributed to a prover."""
@@ -74,12 +90,21 @@ class Counterexample:
     source_line: Optional[int] = None
     #: id of the MIESC finding this counterexample was linked to (if any).
     linked_finding_id: Optional[str] = None
+    #: structured ``name = value`` bindings parsed from ``text`` (best-effort).
+    assignments: List[Dict[str, str]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Auto-parse the witness into structured bindings unless the caller already
+        # supplied them. The raw text is untouched, so this is purely additive.
+        if not self.assignments and self.text:
+            self.assignments = parse_assignments(self.text)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "prover": self.prover,
             "property": self.property,
             "text": self.text,
+            "assignments": self.assignments,
             "source_line": self.source_line,
             "linked_finding_id": self.linked_finding_id,
         }

--- a/tests/test_counterexample_parse.py
+++ b/tests/test_counterexample_parse.py
@@ -1,0 +1,71 @@
+"""Tests for structured counterexample parsing (formal verification, phase 1).
+
+Counterexamples arrive from provers as free text; this turns the `name = value`
+witnesses into structured bindings a PoC generator can consume, while never
+losing the raw text. Sample strings mirror the real formats already asserted in
+tests/test_spec_runner.py.
+"""
+
+import unittest
+
+from miesc.formal.unified_report import Counterexample, parse_assignments
+
+
+class TestParseAssignments(unittest.TestCase):
+    def test_single_assignment(self):
+        self.assertEqual(parse_assignments("amount = 3"), [{"name": "amount", "value": "3"}])
+
+    def test_no_spaces(self):
+        self.assertEqual(parse_assignments("x=1"), [{"name": "x", "value": "1"}])
+
+    def test_comma_separated(self):
+        out = parse_assignments("x = 0, to = 0xdeadbeef")
+        self.assertEqual(out, [{"name": "x", "value": "0"}, {"name": "to", "value": "0xdeadbeef"}])
+
+    def test_multiline(self):
+        text = "\n    balance = 100\n    owner = 0x1\n"
+        out = parse_assignments(text)
+        self.assertEqual([a["name"] for a in out], ["balance", "owner"])
+
+    def test_big_expression_value_preserved(self):
+        out = parse_assignments("amount = 2**256 - 1")
+        self.assertEqual(out, [{"name": "amount", "value": "2**256 - 1"}])
+
+    def test_huge_decimal(self):
+        val = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        self.assertEqual(parse_assignments(f"amount = {val}"), [{"name": "amount", "value": val}])
+
+    def test_no_assignment_returns_empty(self):
+        self.assertEqual(parse_assignments("property violated somewhere"), [])
+
+    def test_empty_text(self):
+        self.assertEqual(parse_assignments(""), [])
+
+
+class TestCounterexampleStructured(unittest.TestCase):
+    def test_auto_populates_assignments_from_text(self):
+        cx = Counterexample(prover="halmos", text="x = 0, amount = 42")
+        self.assertEqual(
+            cx.assignments, [{"name": "x", "value": "0"}, {"name": "amount", "value": "42"}]
+        )
+
+    def test_to_dict_includes_assignments(self):
+        cx = Counterexample(prover="halmos", text="v = 1")
+        d = cx.to_dict()
+        self.assertIn("assignments", d)
+        self.assertEqual(d["assignments"], [{"name": "v", "value": "1"}])
+        self.assertEqual(d["text"], "v = 1")  # raw text preserved
+
+    def test_explicit_assignments_not_overwritten(self):
+        given = [{"name": "custom", "value": "9"}]
+        cx = Counterexample(prover="kontrol", text="x = 1", assignments=given)
+        self.assertEqual(cx.assignments, given)
+
+    def test_unparseable_text_leaves_empty_assignments(self):
+        cx = Counterexample(prover="smtchecker", text="assertion may fail")
+        self.assertEqual(cx.assignments, [])
+        self.assertEqual(cx.text, "assertion may fail")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 1** of the roadmap's counterexample→PoC work, scoped as a clean, standalone increment.

## Why phased
Turning a formal counterexample into an executable PoC needs the counterexample as **structured inputs**, but provers emit it as free text. This phase does the foundational, testable piece — parsing — and surfaces immediate value; later phases map the bindings onto a Foundry PoC and run it.

## What
- `parse_assignments(text)` parses `name = value` witnesses from both the single-line comma-separated form (Halmos/Kontrol: `amount = 3, to = 0x0`) and the indented multi-line form (SMTChecker/solc-mc). Values keep their raw representation (`2**256 - 1`, huge decimals, `0x...`).
- The unified report's `Counterexample` gains an `assignments` field, **auto-populated** from `text` in `__post_init__` and included in `to_dict()`. Purely **additive** — the raw `text` is untouched, so a parse miss loses nothing, and callers can pass explicit assignments to override.

So `miesc verify`'s unified report JSON now carries structured counterexamples, not just opaque strings.

## Tests / safety
12 new tests (parser: single/multi-line, no-space, big expressions, huge decimals, empty; Counterexample: auto-populate, to_dict, explicit-override, unparseable). 25 existing unified_report tests still pass (to_dict change is additive). ruff+black clean. No new deps, no frozen artifacts. Sample strings mirror the real formats in tests/test_spec_runner.py. Sequencing merge on green CI.