### PR TITLE
feat(formal): counterexample→Foundry PoC scaffold (phase 2 of counterexample→PoC)

### DIFF
--- a/miesc/formal/counterexample_poc.py
+++ b/miesc/formal/counterexample_poc.py
@@ -1,0 +1,134 @@
+"""Turn a structured formal counterexample into a Foundry test scaffold.
+
+Phase 2 of counterexample→PoC. Phase 1 parsed a prover's counterexample into
+``name = value`` assignments on :class:`~miesc.formal.unified_report.Counterexample`;
+this lays those concrete values into a Foundry test that reproduces the property
+violation, inferring each input's Solidity type from the prover's variable naming.
+
+The output is a **scaffold**, not a guaranteed-compiling exploit: it plugs in the
+exact counterexample inputs and marks the deploy/call/assert for the developer to
+finish. That is still a large step up from an opaque counterexample string — the
+concrete inputs are already typed and in place.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from miesc.formal.unified_report import Counterexample
+
+# Solidity value types Halmos/Kontrol encode as a suffix on the variable name
+# (e.g. ``p_amount_uint256``, ``halmos_to_address_01``).
+_SOL_TYPE = re.compile(r"^(uint\d*|int\d*|address|bool|bytes\d+|bytes|string)$")
+_DEFAULT_TYPE = "uint256"
+
+
+def _infer_type_and_name(raw_name: str) -> Tuple[str, str]:
+    """Infer ``(solidity_type, clean_name)`` from a prover variable name.
+
+    Handles the Halmos/Kontrol conventions ``p_<name>_<type>`` and
+    ``halmos_<name>_<type>_<id>``; falls back to ``uint256`` and the raw name.
+    """
+    name = raw_name
+    for prefix in ("halmos_", "p_", "kontrol_"):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
+
+    parts = [p for p in name.split("_") if p]
+    sol_type = _DEFAULT_TYPE
+    type_idx = None
+    for i, part in enumerate(parts):
+        if _SOL_TYPE.match(part):
+            sol_type = "uint256" if part == "uint" else "int256" if part == "int" else part
+            type_idx = i
+
+    if type_idx is not None:
+        clean_parts = parts[:type_idx]
+    else:
+        # drop a trailing pure-digit id segment (halmos) if present
+        clean_parts = parts[:-1] if len(parts) > 1 and parts[-1].isdigit() else parts
+
+    clean = "_".join(clean_parts).strip("_")
+    return sol_type, clean or "input"
+
+
+def _format_value(value: str, sol_type: str) -> str:
+    """Render a counterexample value as a Solidity literal for ``sol_type``."""
+    v = value.strip()
+    if sol_type == "bool":
+        return "false" if v in ("0", "false", "False", "") else "true"
+    if sol_type == "address":
+        if v.startswith("0x"):
+            return f"address({v})"
+        return f"address(uint160({v}))"
+    if sol_type.startswith("bytes") and not v.startswith("0x"):
+        # a decimal for a bytes slot is unusual; keep it visible for the dev
+        return v
+    return v
+
+
+def _identifier(cx: "Counterexample", contract_name: str) -> str:
+    base = re.sub(r"[^A-Za-z0-9]", "", contract_name) or "Target"
+    return base[:1].upper() + base[1:]
+
+
+def counterexample_to_foundry_test(
+    cx: "Counterexample",
+    contract_name: str = "Target",
+    test_name: str = "test_reproduce_counterexample",
+) -> str:
+    """Generate a Foundry test scaffold that reproduces ``cx``.
+
+    Each parsed assignment becomes a typed local with the counterexample's exact
+    value; the deploy/call/assert are left as clearly-marked TODOs. Falls back to a
+    commented raw-witness block when the counterexample has no parsed assignments.
+    """
+    name = _identifier(cx, contract_name)
+    prop = cx.property or "the verified property"
+
+    lines: List[str] = []
+    if cx.assignments:
+        seen: Dict[str, int] = {}
+        for a in cx.assignments:
+            raw = str(a.get("name", "")) or "input"
+            sol_type, clean = _infer_type_and_name(raw)
+            # avoid duplicate identifiers
+            ident = clean
+            if ident in seen:
+                seen[ident] += 1
+                ident = f"{clean}_{seen[ident]}"
+            else:
+                seen[ident] = 0
+            value = _format_value(str(a.get("value", "0")), sol_type)
+            lines.append(f"        {sol_type} {ident} = {value}; // {raw}")
+    else:
+        for raw_line in (cx.text or "").splitlines() or [cx.text or ""]:
+            if raw_line.strip():
+                lines.append(f"        // witness: {raw_line.strip()}")
+
+    inputs_block = "\n".join(lines) if lines else "        // (no parsed inputs)"
+
+    return f"""// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+// Auto-generated PoC scaffold from a {cx.prover} counterexample.
+// Property under test: {prop}
+// This is a starting point: deploy the target, call the function under test with
+// the counterexample inputs below, and assert the violated property.
+contract {name}CounterexamplePoC is Test {{
+    function {test_name}() public {{
+        // Counterexample inputs (prover witness):
+{inputs_block}
+
+        // TODO: deploy the contract under test and reproduce the violation, e.g.
+        //   {name} target = new {name}();
+        //   target.functionUnderTest(/* inputs above */);
+        //   assertTrue(/* {prop} holds */, "{prop} violated by the counterexample");
+    }}
+}}
+"""

--- a/miesc/formal/unified_report.py
+++ b/miesc/formal/unified_report.py
@@ -109,6 +109,17 @@ class Counterexample:
             "linked_finding_id": self.linked_finding_id,
         }
 
+    def to_foundry_scaffold(self, contract_name: str = "Target") -> str:
+        """Render a Foundry test scaffold that reproduces this counterexample.
+
+        Lays the parsed ``assignments`` into typed locals with their exact values
+        and marks the deploy/call/assert to complete. Imported lazily to avoid a
+        module cycle.
+        """
+        from miesc.formal.counterexample_poc import counterexample_to_foundry_test
+
+        return counterexample_to_foundry_test(self, contract_name=contract_name)
+
     @classmethod
     def from_text(cls, prover: str, text: str) -> "Counterexample":
         """Build a counterexample, best-effort parsing a source line from ``text``."""

--- a/tests/test_counterexample_poc.py
+++ b/tests/test_counterexample_poc.py
@@ -1,0 +1,105 @@
+"""Tests for the counterexample→Foundry PoC scaffold (phase 2).
+
+Pins that the scaffold plugs in the counterexample's exact values with correctly
+inferred Solidity types, always produces a well-formed test contract, names the
+violated property, and degrades gracefully when no structured inputs are present.
+"""
+
+import unittest
+
+from miesc.formal.counterexample_poc import (
+    _format_value,
+    _infer_type_and_name,
+    counterexample_to_foundry_test,
+)
+from miesc.formal.unified_report import Counterexample
+
+
+class TestTypeInference(unittest.TestCase):
+    def test_halmos_param_naming(self):
+        self.assertEqual(_infer_type_and_name("p_amount_uint256"), ("uint256", "amount"))
+
+    def test_halmos_symbolic_with_id(self):
+        self.assertEqual(_infer_type_and_name("halmos_to_address_01"), ("address", "to"))
+
+    def test_bool_type(self):
+        self.assertEqual(_infer_type_and_name("p_flag_bool"), ("bool", "flag"))
+
+    def test_bytes32(self):
+        self.assertEqual(_infer_type_and_name("p_hash_bytes32"), ("bytes32", "hash"))
+
+    def test_bare_uint_defaults_to_256(self):
+        self.assertEqual(_infer_type_and_name("p_x_uint"), ("uint256", "x"))
+
+    def test_unknown_name_defaults(self):
+        sol_type, name = _infer_type_and_name("amount")
+        self.assertEqual(sol_type, "uint256")
+        self.assertEqual(name, "amount")
+
+
+class TestValueFormatting(unittest.TestCase):
+    def test_bool(self):
+        self.assertEqual(_format_value("0", "bool"), "false")
+        self.assertEqual(_format_value("1", "bool"), "true")
+
+    def test_address_hex(self):
+        self.assertEqual(_format_value("0xdeadbeef", "address"), "address(0xdeadbeef)")
+
+    def test_address_decimal(self):
+        self.assertEqual(_format_value("0", "address"), "address(uint160(0))")
+
+    def test_numeric_passthrough(self):
+        self.assertEqual(_format_value("42", "uint256"), "42")
+
+
+class TestScaffoldGeneration(unittest.TestCase):
+    def test_scaffold_has_typed_inputs_with_values(self):
+        cx = Counterexample(
+            prover="halmos",
+            text="p_amount_uint256 = 42, p_to_address = 0x1",
+            property="balance never underflows",
+        )
+        out = counterexample_to_foundry_test(cx, contract_name="Vault")
+        # structure
+        self.assertIn('import "forge-std/Test.sol";', out)
+        self.assertIn("contract VaultCounterexamplePoC is Test", out)
+        self.assertIn("balance never underflows", out)
+        # typed inputs with the counterexample's exact values
+        self.assertIn("uint256 amount = 42;", out)
+        self.assertIn("address to = address(0x1);", out)
+
+    def test_scaffold_names_the_test_function(self):
+        cx = Counterexample(prover="kontrol", text="x = 1")
+        out = counterexample_to_foundry_test(cx, test_name="test_myprop")
+        self.assertIn("function test_myprop() public", out)
+
+    def test_no_assignments_falls_back_to_witness_comment(self):
+        cx = Counterexample(prover="smtchecker", text="assertion may fail at line 12")
+        self.assertEqual(cx.assignments, [])  # unparseable -> empty (phase 1)
+        out = counterexample_to_foundry_test(cx)
+        self.assertIn("// witness: assertion may fail at line 12", out)
+        self.assertIn("is Test", out)  # still a valid contract shell
+
+    def test_duplicate_names_disambiguated(self):
+        cx = Counterexample(prover="halmos", text="p_x_uint256 = 1, x = 2")
+        out = counterexample_to_foundry_test(cx)
+        # both bindings appear; identifiers must not collide
+        self.assertIn("uint256 x = 1;", out)
+        self.assertIn("x_1 = 2;", out)
+
+    def test_output_is_balanced_braces(self):
+        cx = Counterexample(prover="halmos", text="p_a_uint256 = 5")
+        out = counterexample_to_foundry_test(cx)
+        self.assertEqual(out.count("{"), out.count("}"))
+
+
+class TestCounterexampleMethod(unittest.TestCase):
+    def test_to_foundry_scaffold_method(self):
+        cx = Counterexample(prover="halmos", text="p_amount_uint256 = 7", property="no overflow")
+        out = cx.to_foundry_scaffold(contract_name="Bank")
+        self.assertIn("contract BankCounterexamplePoC is Test", out)
+        self.assertIn("uint256 amount = 7;", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 2** — turns the structured counterexamples from #100 into an executable-shaped Foundry test.

## What
`counterexample_to_foundry_test(cx)` (and `Counterexample.to_foundry_scaffold()`) lays each parsed `name = value` assignment into a **typed Solidity local with the counterexample's exact value**, inferring the type from the prover's variable naming (`p_amount_uint256` → `uint256 amount`, `halmos_to_address_01` → `address to`, `p_flag_bool` → `bool flag`), names the violated property, and marks the deploy/call/assert as TODO.

```solidity
contract TokenCounterexamplePoC is Test {
    function test_reproduce_counterexample() public {
        // Counterexample inputs (prover witness):
        uint256 amount = 1157920892...639935; // p_amount_uint256
        address to = address(0x0);            // p_to_address
        bool flag = false;                    // p_flag_bool
        // TODO: deploy the target, call the function, assert the property
    }
}
```

## Honest scope
It's a **scaffold**, not a guaranteed-compiling exploit — the developer wires the deploy/call/assert. But the concrete inputs are already typed and in place, a large step from an opaque witness string. No-assignment counterexamples degrade to a commented witness block.

## Tests / safety
16 tests (type inference incl. Halmos/Kontrol naming, value formatting for bool/address/numeric, scaffold structure + exact values, duplicate-name disambiguation, balanced braces, no-assignment fallback, the convenience method). No import cycle (lazy import); 25 existing unified_report tests still pass. ruff+black clean. Pure-Python, no new deps, no frozen artifacts. Phase 3 (CLI `verify` hook) is the natural follow-up. Sequencing merge on green CI.