### PR TITLE
feat(core): pluggable acceptance-pattern provider (closes #84)

### DIFF
--- a/miesc/cli/commands/scan.py
+++ b/miesc/cli/commands/scan.py
@@ -201,6 +201,17 @@ if RICH_AVAILABLE:
     help="Only send --notify/--slack when at least one finding reaches this "
     "severity (default: low).",
 )
+@click.option(
+    "--acceptance-provider",
+    "acceptance_provider",
+    type=click.Choice(["none", "local", "bugbounty"], case_sensitive=False),
+    default="none",
+    help="Reorder findings by historical acceptance probability (how often a "
+    "finding of this class is accepted by human judges in competitive audits). "
+    "'local' uses the free offline table; 'bugbounty' uses an opt-in external "
+    "service (must be enabled + API key). Recall-safe: reorders only, never "
+    "drops (recall 1.0). Default: none.",
+)
 def scan(
     contract: str,
     output: str | None,
@@ -226,6 +237,7 @@ def scan(
     notify_url: str | None,
     slack_url: str | None,
     notify_min_severity: str,
+    acceptance_provider: str,
 ) -> None:
     """Quick vulnerability scan for a Solidity contract or directory.
 
@@ -336,6 +348,7 @@ def scan(
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
+            acceptance_provider=acceptance_provider,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
             annotate=annotate,
@@ -364,6 +377,7 @@ def scan(
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
+            acceptance_provider=acceptance_provider,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
             annotate=annotate,
@@ -556,6 +570,7 @@ def scan(
             verify_fp=verify_fp,
             verify_model=verify_model,
             rank=rank,
+            acceptance_provider=acceptance_provider,
             baseline_path=baseline_path,
             fail_on_new=fail_on_new,
             annotate=annotate,
@@ -869,6 +884,7 @@ def scan(
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
+        acceptance_provider=acceptance_provider,
         baseline_path=baseline_path,
         fail_on_new=fail_on_new,
         annotate=annotate,
@@ -960,6 +976,7 @@ def _run_agentic_scan_profile(
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
+    acceptance_provider: str = "none",
     baseline_path: str | None = None,
     fail_on_new: bool = False,
     annotate: str | None = None,
@@ -1005,6 +1022,7 @@ def _run_agentic_scan_profile(
         verify_fp=verify_fp,
         verify_model=verify_model,
         rank=rank,
+        acceptance_provider=acceptance_provider,
         baseline_path=baseline_path,
         fail_on_new=fail_on_new,
         annotate=annotate,
@@ -1092,6 +1110,47 @@ def _apply_triage_rank(all_results: list[dict[str, Any]], *, contract: str, quie
             )
 
 
+def _apply_acceptance_ordering(
+    all_results: list[dict[str, Any]], *, choice: str, quiet: bool
+) -> None:
+    """Reorder findings by historical acceptance probability — recall-safe.
+
+    Annotates ``finding['acceptance_prob']`` and orders higher-acceptance
+    findings first. Never drops a finding (recall 1.0) and never touches the
+    confidence/``--min-confidence`` path. ``choice`` selects the provider:
+    'local' (free, offline) or 'bugbounty' (opt-in external). No-ops gracefully
+    when the chosen provider is unavailable."""
+    try:
+        from miesc.core.acceptance_contracts import AcceptancePolicy
+        from miesc.core.acceptance_providers import (
+            BugBountyIntelligenceProvider,
+            LocalAcceptancePatternProvider,
+        )
+        from miesc.ml.triage_ranker import apply_acceptance_ordering
+    except Exception as e:  # noqa: BLE001
+        if not quiet:
+            info(f"acceptance ordering skipped: {e}")
+        return
+    if choice == "bugbounty":
+        provider: Any = BugBountyIntelligenceProvider(
+            config={"enabled": True}, policy=AcceptancePolicy(allow_remote=True)
+        )
+    else:
+        provider = LocalAcceptancePatternProvider()
+    total = apply_acceptance_ordering(all_results, provider=provider)
+    if not quiet:
+        if total < 0:
+            info(
+                f"acceptance ({choice}): provider unavailable — order unchanged "
+                "(recall-safe no-op)"
+            )
+        else:
+            info(
+                f"acceptance ({choice}): annotated + reordered {total} finding(s) by "
+                "acceptance probability — recall-safe (nothing dropped)"
+            )
+
+
 def _display_and_save(
     all_results: list[dict[str, Any]],
     *,
@@ -1105,6 +1164,7 @@ def _display_and_save(
     verify_fp: bool = False,
     verify_model: str | None = None,
     rank: bool = False,
+    acceptance_provider: str = "none",
     baseline_path: str | None = None,
     fail_on_new: bool = False,
     annotate: str | None = None,
@@ -1117,6 +1177,8 @@ def _display_and_save(
         _apply_verify_fp(all_results, contract=contract, model=verify_model, quiet=quiet)
     if rank:
         _apply_triage_rank(all_results, contract=contract, quiet=quiet)
+    if acceptance_provider and acceptance_provider.lower() != "none":
+        _apply_acceptance_ordering(all_results, choice=acceptance_provider.lower(), quiet=quiet)
 
     # Attach a calibrated confidence score to every scan finding (scan runs its own
     # adapter + FP-filter pipeline, so findings arrive un-annotated). Mirrors the ML

--- a/miesc/core/acceptance_contracts.py
+++ b/miesc/core/acceptance_contracts.py
@@ -1,0 +1,138 @@
+"""
+Provider-neutral contracts for acceptance-pattern intelligence.
+
+An *acceptance-pattern* provider answers a single question about a finding:
+"historically, how often do human judges in competitive audits (Sherlock,
+Code4rena, ...) ACCEPT a finding of this class as valid?" The answer is a
+probability in ``[0, 1]`` used purely as an ORDERING / prioritization signal.
+
+Why this module exists (ports & adapters):
+
+The MIESC public core must not be coupled to any external, paid, or proprietary
+service. A third party may offer "bug bounty intelligence" as a paid API, but
+coupling the core to it would break DPGA platform-independence and privacy
+guarantees. So instead we define a *port* (this file) and ship two adapters of
+different nature (``acceptance_providers``): a real, offline, always-available
+local default, and an opt-in external adapter. Two implementations of different
+nature prove the abstraction is genuine.
+
+This mirrors the replaceable-provider shape already used for agentic reasoning
+(:mod:`miesc.llm.agentic_contracts`): a ``typing.Protocol`` interface plus a
+local-first, remote-off-by-default policy dataclass
+(:class:`AcceptancePolicy`, analogous to ``DPGAgentConfig``).
+
+RECALL-SAFETY (locked design decision): an acceptance probability may only
+influence ORDERING. It MUST NOT feed any confidence blend or drop/filter path.
+A low-acceptance finding drops in rank but stays fully visible — recall stays
+1.0. See :mod:`miesc.ml.triage_ranker` for the reorder-only integration.
+
+Author: Fernando Boiero <fboiero@frvm.utn.edu.ar>
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from miesc.core.finding_taxonomy import CanonicalCategory, normalize_finding_type
+
+
+@dataclass(frozen=True)
+class AcceptancePolicy:
+    """Policy knobs that keep acceptance intelligence local-first and replaceable.
+
+    Mirrors ``miesc.llm.agentic_contracts.DPGAgentConfig``: the core defaults to
+    a local provider and never reaches out to a remote service unless the
+    operator explicitly opts in.
+    """
+
+    local_first: bool = True
+    allow_remote: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "local_first": bool(self.local_first),
+            "allow_remote": bool(self.allow_remote),
+        }
+
+
+@dataclass(frozen=True)
+class AcceptanceSignal:
+    """A provider-neutral acceptance-probability observation for a vuln class."""
+
+    vuln_class: str
+    acceptance_prob: float
+    provider: str = "unspecified"
+    swc_id: str = ""
+    sample_note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "vuln_class": str(self.vuln_class),
+            "acceptance_prob": _clamp_probability(self.acceptance_prob),
+            "provider": str(self.provider) or "unspecified",
+            "swc_id": str(self.swc_id),
+            "sample_note": str(self.sample_note),
+        }
+
+
+@runtime_checkable
+class AcceptancePatternProvider(Protocol):
+    """Interface implemented by local, external, mock, or future providers.
+
+    Implementations MUST be graceful: an unavailable provider returns ``False``
+    from :meth:`is_available` and ``None`` from :meth:`acceptance_probability`
+    rather than raising, so callers can no-op and leave ordering unchanged.
+    """
+
+    name: str
+
+    def is_available(self) -> bool:
+        """Return True when this provider can answer queries (opt-in aware)."""
+
+    def list_vulnerability_patterns(self) -> Dict[str, float]:
+        """Return a cheap map of vuln class -> acceptance probability in [0, 1]."""
+
+    def acceptance_probability(
+        self,
+        finding: Dict[str, Any],
+        protocol_type: Optional[str] = None,
+    ) -> Optional[float]:
+        """Return the acceptance probability for ``finding`` in ``[0, 1]``.
+
+        Returns ``None`` when the class is unknown — the caller must then leave
+        the finding's rank unchanged (never guess, never drop).
+        """
+
+
+def finding_to_vuln_class(finding: Any) -> Optional[str]:
+    """Map a finding (or raw type string) to a canonical vuln-class key.
+
+    Delegates to :func:`miesc.core.finding_taxonomy.normalize_finding_type` so
+    providers share MIESC's single source of truth for the taxonomy instead of
+    reinventing it. Returns the canonical string value, or ``None`` if unknown.
+    """
+    category: Optional[CanonicalCategory] = normalize_finding_type(finding)
+    if category is None:
+        return None
+    return category.value
+
+
+def _clamp_probability(value: Any) -> float:
+    """Clamp ``value`` into ``[0.0, 1.0]``; non-numeric -> ``0.0``."""
+    try:
+        prob = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if prob != prob:  # NaN
+        return 0.0
+    return max(0.0, min(1.0, prob))
+
+
+__all__ = [
+    "AcceptancePolicy",
+    "AcceptanceSignal",
+    "AcceptancePatternProvider",
+    "finding_to_vuln_class",
+]

--- a/miesc/core/acceptance_providers.py
+++ b/miesc/core/acceptance_providers.py
@@ -1,0 +1,280 @@
+"""
+Adapters for the acceptance-pattern intelligence port.
+
+Two implementations of *different nature* prove the abstraction defined in
+:mod:`miesc.core.acceptance_contracts` is genuinely provider-neutral:
+
+* :class:`LocalAcceptancePatternProvider` — the DEFAULT. Offline, deterministic,
+  always available. Reads the curated open table shipped at
+  ``miesc/knowledge_base/acceptance_patterns.json``. Real and functional.
+
+* :class:`BugBountyIntelligenceProvider` — an OPT-IN external adapter for a
+  third-party "bug bounty intelligence" service. It is unavailable unless the
+  operator explicitly enables it (config ``enabled: true`` + an API-key env var)
+  AND the acceptance policy allows remote traffic. Its network calls pass the
+  SSRF guard (:func:`miesc.core.net_guard.guard_outbound_url`) with a host
+  allowlist. The service's paid, on-chain-charged ``scan_contract`` path is a
+  documented extension point that raises ``NotImplementedError`` — the public
+  core ships no payment integration.
+
+Mirrors ``miesc.llm.reasoning_provider_adapter``: a local-heuristic default, a
+configured/remote implementation guarded by an ``allow_remote`` policy, and an
+``auto_*`` factory that returns local unless remote is explicitly wired.
+
+Author: Fernando Boiero <fboiero@frvm.utn.edu.ar>
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from miesc.core.acceptance_contracts import (
+    AcceptancePatternProvider,
+    AcceptancePolicy,
+    finding_to_vuln_class,
+)
+from miesc.core.net_guard import SSRFError, guard_outbound_url
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the curated local acceptance table.
+_DEFAULT_DATA_PATH = (
+    Path(__file__).resolve().parent.parent / "knowledge_base" / "acceptance_patterns.json"
+)
+
+#: Outbound request timeout for the external adapter (seconds).
+_REQUEST_TIMEOUT_SECONDS = 10
+
+#: Environment variable holding the external service API key (opt-in).
+_BUGBOUNTY_API_KEY_ENV = "MIESC_BUGBOUNTY_API_KEY"
+
+
+def _clamp(value: Any) -> Optional[float]:
+    """Return ``value`` clamped into ``[0, 1]``, or ``None`` if non-numeric/NaN."""
+    try:
+        prob = float(value)
+    except (TypeError, ValueError):
+        return None
+    if prob != prob:  # NaN
+        return None
+    return max(0.0, min(1.0, prob))
+
+
+class LocalAcceptancePatternProvider(AcceptancePatternProvider):
+    """Offline, always-available default backed by a curated JSON table."""
+
+    name = "local-acceptance-patterns"
+
+    def __init__(self, data_path: Optional[str] = None) -> None:
+        self._data_path = Path(data_path) if data_path else _DEFAULT_DATA_PATH
+        self._patterns: Dict[str, float] = {}
+        self._raw: Dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self._data_path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError) as exc:  # missing/corrupt table -> degrade
+            logger.warning("Acceptance: could not load local table %s: %s", self._data_path, exc)
+            return
+        patterns = data.get("patterns") if isinstance(data, Mapping) else None
+        if not isinstance(patterns, Mapping):
+            logger.warning("Acceptance: local table has no 'patterns' object")
+            return
+        for key, entry in patterns.items():
+            if not isinstance(entry, Mapping):
+                continue
+            prob = _clamp(entry.get("acceptance_prob"))
+            if prob is None:
+                continue
+            self._patterns[str(key)] = prob
+        self._raw = dict(patterns)
+
+    def is_available(self) -> bool:
+        return bool(self._patterns)
+
+    def list_vulnerability_patterns(self) -> Dict[str, float]:
+        return dict(self._patterns)
+
+    def acceptance_probability(
+        self,
+        finding: Dict[str, Any],
+        protocol_type: Optional[str] = None,
+    ) -> Optional[float]:
+        del protocol_type  # local table is protocol-agnostic
+        vuln_class = finding_to_vuln_class(finding)
+        if vuln_class is None:
+            return None
+        return self._patterns.get(vuln_class)
+
+
+class BugBountyIntelligenceProvider(AcceptancePatternProvider):
+    """Opt-in adapter for a third-party bug-bounty-intelligence service.
+
+    Availability is gated by three independent conditions (all required):
+
+    1. The acceptance policy allows remote traffic (``allow_remote=True``).
+    2. Config enablement (``enabled=True`` passed via ``config``).
+    3. An API key present in the ``MIESC_BUGBOUNTY_API_KEY`` environment
+       variable (env var name mirrors the certora ``api_key_env`` convention).
+
+    All outbound requests pass :func:`guard_outbound_url` with a host allowlist,
+    so localhost / private / reserved targets are rejected (SSRF-safe).
+    """
+
+    name = "bugbounty-intelligence"
+
+    #: The vendor's FREE, cheap "list patterns" endpoint (illustrative host).
+    #: Overridable via config ``base_url``; must be HTTPS and pass the guard.
+    _DEFAULT_BASE_URL = "https://api.bugbounty-intelligence.example"
+
+    def __init__(
+        self,
+        *,
+        config: Optional[Mapping[str, Any]] = None,
+        policy: Optional[AcceptancePolicy] = None,
+        opener: Optional[Any] = None,
+    ) -> None:
+        cfg = dict(config or {})
+        self._policy = policy or AcceptancePolicy()
+        self._enabled = bool(cfg.get("enabled", False))
+        self._api_key_env = str(cfg.get("api_key_env") or _BUGBOUNTY_API_KEY_ENV)
+        self._base_url = str(cfg.get("base_url") or self._DEFAULT_BASE_URL).rstrip("/")
+        # Injectable opener keeps tests fully offline (no real network).
+        self._opener = opener
+
+    # -- opt-in gating ------------------------------------------------------
+
+    def _api_key(self) -> str:
+        return os.environ.get(self._api_key_env, "").strip()
+
+    def is_available(self) -> bool:
+        if not self._policy.allow_remote:
+            return False
+        if not self._enabled:
+            return False
+        return bool(self._api_key())
+
+    # -- port surface -------------------------------------------------------
+
+    def list_vulnerability_patterns(self) -> Dict[str, float]:
+        """Call the vendor's FREE list endpoint. Returns ``{}`` on any failure."""
+        if not self.is_available():
+            return {}
+        url = f"{self._base_url}/v1/vulnerability-patterns"
+        payload = self._get_json(url)
+        if not isinstance(payload, Mapping):
+            return {}
+        raw = payload.get("patterns", payload)
+        result: Dict[str, float] = {}
+        if isinstance(raw, Mapping):
+            for key, value in raw.items():
+                prob = _clamp(
+                    value if not isinstance(value, Mapping) else value.get("acceptance_prob")
+                )
+                if prob is not None:
+                    result[str(key)] = prob
+        return result
+
+    def acceptance_probability(
+        self,
+        finding: Dict[str, Any],
+        protocol_type: Optional[str] = None,
+    ) -> Optional[float]:
+        del protocol_type
+        if not self.is_available():
+            return None
+        vuln_class = finding_to_vuln_class(finding)
+        if vuln_class is None:
+            return None
+        return self.list_vulnerability_patterns().get(vuln_class)
+
+    def scan_contract(self, *args: Any, **kwargs: Any) -> Any:
+        """Paid, x402-metered per-contract scan — an opt-in extension point.
+
+        Deliberately unimplemented in the public core: it would require an
+        on-chain payment integration we do not ship.
+        """
+        raise NotImplementedError(
+            "paid x402 scan is an opt-in extension point; not shipped in core"
+        )
+
+    # -- guarded transport --------------------------------------------------
+
+    def _get_json(self, url: str) -> Optional[Any]:
+        """HTTPS GET ``url`` after SSRF validation. Never raises; ``None`` on error."""
+        if not self._policy.allow_remote:
+            logger.info("Acceptance: remote disabled by policy, not calling %s", url)
+            return None
+        try:
+            allowed_host = self._host_of(self._base_url)
+            guard_outbound_url(url, allowed_hosts=[allowed_host] if allowed_host else None)
+        except SSRFError as exc:
+            logger.warning("Acceptance: URL rejected by SSRF guard, not calling: %s", exc)
+            return None
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self._api_key()}",
+                "User-Agent": "MIESC-acceptance",
+            },
+            method="GET",
+        )
+        try:
+            opener = self._opener or urllib.request.urlopen
+            with opener(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
+                body = response.read()
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+            logger.warning("Acceptance: failed to reach service: %s", exc)
+            return None
+        try:
+            return json.loads(body)
+        except (ValueError, TypeError) as exc:
+            logger.warning("Acceptance: invalid JSON from service: %s", exc)
+            return None
+
+    @staticmethod
+    def _host_of(base_url: str) -> str:
+        from urllib.parse import urlparse
+
+        return (urlparse(base_url).hostname or "").lower()
+
+
+def auto_acceptance_provider(
+    prefer_local: bool = True,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    policy: Optional[AcceptancePolicy] = None,
+) -> AcceptancePatternProvider:
+    """Return an acceptance provider suitable for DPG local-first workflows.
+
+    Returns the offline :class:`LocalAcceptancePatternProvider` by default. The
+    external :class:`BugBountyIntelligenceProvider` is returned only when the
+    caller explicitly opts in (``prefer_local=False`` with an enabled config and
+    a remote-allowing policy) AND that provider reports itself available;
+    otherwise it falls back to local.
+    """
+    if prefer_local or config is None:
+        return LocalAcceptancePatternProvider()
+
+    effective_policy = policy or AcceptancePolicy(allow_remote=True)
+    external = BugBountyIntelligenceProvider(config=config, policy=effective_policy)
+    if external.is_available():
+        return external
+    return LocalAcceptancePatternProvider()
+
+
+__all__ = [
+    "LocalAcceptancePatternProvider",
+    "BugBountyIntelligenceProvider",
+    "auto_acceptance_provider",
+]

--- a/miesc/data/config/miesc.yaml
+++ b/miesc/data/config/miesc.yaml
@@ -894,6 +894,25 @@ analysis:
 # v4.3.0+ Nuevas Capas de Inteligencia (2025-2026)
 # =============================================================================
 intelligence:
+  # Acceptance-pattern intelligence (pluggable, ports-and-adapters).
+  # Provides a per-vulnerability-class "acceptance probability": how often a
+  # finding of this class is historically ACCEPTED as valid by human judges in
+  # competitive audits (Sherlock, Code4rena, ...). RECALL-SAFE: this signal only
+  # reorders findings by priority — it never feeds confidence and never drops
+  # anything (recall stays 1.0).
+  acceptance:
+    # Local, offline, curated open table — the default provider. Always safe.
+    local:
+      enabled: true
+    # Opt-in EXTERNAL provider (a third-party bug-bounty-intelligence service).
+    # Off by default; requires an API key and honors the local-first policy.
+    # The paid per-contract (x402) scan is NOT shipped in core.
+    bugbounty:
+      enabled: false            # must be explicitly enabled
+      api_key_env: MIESC_BUGBOUNTY_API_KEY
+      allow_remote: false       # remote traffic stays off unless opted in
+      base_url: null            # override the vendor endpoint (HTTPS, SSRF-guarded)
+
   # LLM Ensemble Detector - Multi-model voting
   ensemble_detection:
     enabled: true

--- a/miesc/knowledge_base/acceptance_patterns.json
+++ b/miesc/knowledge_base/acceptance_patterns.json
@@ -1,0 +1,97 @@
+{
+  "_meta": {
+    "schema_version": "1.0.0",
+    "name": "MIESC acceptance-pattern intelligence (local default)",
+    "description": "Approximate acceptance probabilities per vulnerability CLASS: how often a submitted finding of this class is historically ACCEPTED as valid by human judges in competitive audits (Sherlock, Code4rena, and similar).",
+    "provenance": "Curated by hand from PUBLIC competitive-audit outcome reports and post-mortems. These are small, honest, illustrative class-level rates chosen by the MIESC maintainers to seed the local provider. They are NOT a reproduction of any vendor's proprietary dataset and do NOT claim any specific corpus size. Any commercial 'bug bounty intelligence' service with a larger proprietary corpus is a separate opt-in adapter (see miesc.core.acceptance_providers.BugBountyIntelligenceProvider).",
+    "usage": "REORDER-ONLY signal. acceptance_prob annotates finding['acceptance_prob'] and influences ranking/priority only. It is NEVER blended into confidence and NEVER feeds a drop/filter path. A low-acceptance finding ranks lower but stays fully visible (recall stays 1.0).",
+    "keying": "Keys are MIESC canonical categories (miesc.core.finding_taxonomy.CanonicalCategory). Findings are mapped to a key via normalize_finding_type().",
+    "fields": {
+      "acceptance_prob": "float in [0,1] — approximate share of submitted findings in this class accepted as valid",
+      "swc_id": "representative SWC registry id for the class (informational)",
+      "sample_note": "short human note on why this class tends to be accepted or contested"
+    }
+  },
+  "patterns": {
+    "reentrancy": {
+      "swc_id": "SWC-107",
+      "acceptance_prob": 0.72,
+      "sample_note": "High-signal, demonstrable with a PoC; frequently accepted when an external call precedes a state update."
+    },
+    "access_control": {
+      "swc_id": "SWC-105",
+      "acceptance_prob": 0.68,
+      "sample_note": "Missing/incorrect authorization on privileged functions is usually clear-cut and accepted."
+    },
+    "oracle_manipulation": {
+      "swc_id": "SWC-000",
+      "acceptance_prob": 0.63,
+      "sample_note": "Accepted when spot-price/reserve reliance is shown exploitable; contested when a TWAP or sanity bound already mitigates it."
+    },
+    "flash_loan": {
+      "swc_id": "SWC-000",
+      "acceptance_prob": 0.55,
+      "sample_note": "Often a vector rather than a root cause; accepted when it unlocks a concrete accounting or price break."
+    },
+    "arithmetic": {
+      "swc_id": "SWC-101",
+      "acceptance_prob": 0.45,
+      "sample_note": "Overflow/underflow acceptance dropped sharply after Solidity 0.8 checked math; precision/rounding drift still accepted."
+    },
+    "unchecked_call": {
+      "swc_id": "SWC-104",
+      "acceptance_prob": 0.42,
+      "sample_note": "Frequently contested as low severity unless a silent failure leads to a concrete loss."
+    },
+    "initialization": {
+      "swc_id": "SWC-118",
+      "acceptance_prob": 0.6,
+      "sample_note": "Uninitialized proxy / re-initializable state is high-impact and generally accepted."
+    },
+    "signature_verification": {
+      "swc_id": "SWC-117",
+      "acceptance_prob": 0.61,
+      "sample_note": "Replay / missing-domain / malleability issues are accepted when a concrete replay path is shown."
+    },
+    "bad_randomness": {
+      "swc_id": "SWC-120",
+      "acceptance_prob": 0.5,
+      "sample_note": "Accepted when on-chain randomness gates value; contested for cosmetic or off-chain-mitigated uses."
+    },
+    "time_manipulation": {
+      "swc_id": "SWC-116",
+      "acceptance_prob": 0.38,
+      "sample_note": "block.timestamp reliance is often judged low severity given miner drift is bounded."
+    },
+    "denial_of_service": {
+      "swc_id": "SWC-113",
+      "acceptance_prob": 0.47,
+      "sample_note": "Accepted for unbounded loops / griefing that lock funds; contested when only gas-costly, not fund-locking."
+    },
+    "front_running": {
+      "swc_id": "SWC-114",
+      "acceptance_prob": 0.4,
+      "sample_note": "MEV/ordering findings are frequently contested unless a concrete, unmitigated value extraction is demonstrated."
+    },
+    "proxy_upgrade": {
+      "swc_id": "SWC-112",
+      "acceptance_prob": 0.58,
+      "sample_note": "Storage-collision / unauthorized-upgrade paths are high-impact and generally accepted when demonstrable."
+    },
+    "centralization": {
+      "swc_id": "SWC-000",
+      "acceptance_prob": 0.35,
+      "sample_note": "Privileged-role/admin-power findings are often downgraded to informational unless an unexpected trust break is shown."
+    },
+    "input_validation": {
+      "swc_id": "SWC-123",
+      "acceptance_prob": 0.44,
+      "sample_note": "Accepted when missing validation enables a concrete exploit; otherwise commonly triaged as low/QA."
+    },
+    "other": {
+      "swc_id": "SWC-000",
+      "acceptance_prob": 0.3,
+      "sample_note": "Unclassified findings default low; judges require a clear impact statement before acceptance."
+    }
+  }
+}

--- a/miesc/ml/triage_ranker.py
+++ b/miesc/ml/triage_ranker.py
@@ -196,6 +196,59 @@ def rank_results(all_results: list[dict[str, Any]], *, contract: str = "") -> in
     return total
 
 
+def apply_acceptance_ordering(
+    all_results: list[dict[str, Any]],
+    *,
+    provider: Any = None,
+) -> int:
+    """Annotate ``finding['acceptance_prob']`` and reorder findings by it — recall-safe.
+
+    The acceptance probability (how often human judges historically ACCEPT a
+    finding of this class in competitive audits) is a pure ORDERING signal:
+    higher-acceptance findings surface first. This NEVER drops a finding
+    (recall stays 1.0) and NEVER feeds the confidence/``--min-confidence`` path
+    — it only annotates and reorders. Findings whose class is unknown keep their
+    relative order and sink below scored ones, but remain fully visible.
+
+    Defaults to the offline local provider (free/safe). Returns the number of
+    findings annotated, or ``-1`` when no acceptance provider is available
+    (caller leaves order unchanged). Injectable ``provider`` keeps tests offline.
+    """
+    if provider is None:
+        from miesc.core.acceptance_providers import auto_acceptance_provider
+
+        provider = auto_acceptance_provider()
+    try:
+        if not provider.is_available():
+            return -1
+    except Exception:  # noqa: BLE001 — a broken provider must not abort a scan
+        return -1
+
+    total = 0
+    for result in all_results:
+        fs = result.get("findings") or []
+        if not fs:
+            continue
+        probs: dict[int, float] = {}
+        for idx, f in enumerate(fs):
+            try:
+                prob = provider.acceptance_probability(f)
+            except Exception:  # noqa: BLE001 — never let annotation break a scan
+                prob = None
+            if prob is not None:
+                f["acceptance_prob"] = round(float(prob), 4)
+                probs[idx] = float(prob)
+                total += 1
+        # Stable sort: known acceptance descending, unknown (default -1.0) keep
+        # original relative order at the bottom. Count in == count out (recall-safe).
+        order = sorted(
+            range(len(fs)),
+            key=lambda i: -probs.get(i, -1.0),
+        )
+        result["findings"] = [fs[i] for i in order]
+    return total
+
+
 def train(dataset_path: str, model_path: str = DEFAULT_MODEL_PATH) -> dict[str, Any]:
     """Train the GradientBoosting triage model on a labeled JSONL dataset
     ({"finding": {...}, "context": "...", "label": true/false}; True = real) and persist it.

--- a/tests/test_acceptance_patterns.py
+++ b/tests/test_acceptance_patterns.py
@@ -1,0 +1,317 @@
+"""
+Tests for the pluggable acceptance-pattern intelligence provider.
+
+Covers the ports-and-adapters design (miesc.core.acceptance_contracts /
+acceptance_providers) plus the recall-safe ordering integration in
+miesc.ml.triage_ranker and the scan CLI wiring. All network is mocked — no
+test touches the real internet.
+
+Key guarantees under test:
+  * Protocol conformance for both adapters.
+  * Local provider returns real probabilities for known classes, None otherwise.
+  * Finding -> vuln-class mapping goes through normalize_finding_type.
+  * RECALL-SAFE: acceptance reordering never drops a finding (count in == out).
+  * External adapter is opt-in (off by default), SSRF-guarded, and its paid
+    scan path is unimplemented; allow_remote=False blocks remote calls.
+  * Factory returns the local provider by default.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from miesc.core.acceptance_contracts import (
+    AcceptancePatternProvider,
+    AcceptancePolicy,
+    AcceptanceSignal,
+    finding_to_vuln_class,
+)
+from miesc.core.acceptance_providers import (
+    _DEFAULT_DATA_PATH,
+    BugBountyIntelligenceProvider,
+    LocalAcceptancePatternProvider,
+    auto_acceptance_provider,
+)
+from miesc.ml.triage_ranker import apply_acceptance_ordering
+
+
+def _finding(vtype: str, severity: str = "high") -> dict:
+    return {"type": vtype, "check": vtype, "severity": severity}
+
+
+# --------------------------------------------------------------------------- #
+# Port / protocol conformance
+# --------------------------------------------------------------------------- #
+class TestProtocolConformance:
+    def test_local_provider_satisfies_protocol(self):
+        provider = LocalAcceptancePatternProvider()
+        assert isinstance(provider, AcceptancePatternProvider)
+        assert isinstance(provider.name, str) and provider.name
+
+    def test_external_provider_satisfies_protocol(self):
+        provider = BugBountyIntelligenceProvider()
+        assert isinstance(provider, AcceptancePatternProvider)
+        assert isinstance(provider.name, str) and provider.name
+
+    def test_policy_defaults_are_local_first_remote_off(self):
+        policy = AcceptancePolicy()
+        assert policy.local_first is True
+        assert policy.allow_remote is False
+        assert policy.to_dict() == {"local_first": True, "allow_remote": False}
+
+    def test_acceptance_signal_clamps_probability(self):
+        assert AcceptanceSignal("reentrancy", 1.5).to_dict()["acceptance_prob"] == 1.0
+        assert AcceptanceSignal("reentrancy", -0.2).to_dict()["acceptance_prob"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Finding -> vuln class mapping (via normalize_finding_type)
+# --------------------------------------------------------------------------- #
+class TestFindingMapping:
+    def test_known_type_maps_to_canonical_class(self):
+        assert finding_to_vuln_class(_finding("reentrancy-eth")) == "reentrancy"
+        assert finding_to_vuln_class({"swc_id": "SWC-105"}) == "access_control"
+
+    def test_unknown_type_returns_none(self):
+        assert finding_to_vuln_class(_finding("totally-made-up-xyz")) is None
+
+
+# --------------------------------------------------------------------------- #
+# Local provider — real probs for known classes, None for unknown
+# --------------------------------------------------------------------------- #
+class TestLocalProvider:
+    def test_is_available_and_lists_patterns(self):
+        provider = LocalAcceptancePatternProvider()
+        assert provider.is_available() is True
+        patterns = provider.list_vulnerability_patterns()
+        assert "reentrancy" in patterns
+        assert all(0.0 <= v <= 1.0 for v in patterns.values())
+
+    def test_known_class_returns_real_probability(self):
+        provider = LocalAcceptancePatternProvider()
+        prob = provider.acceptance_probability(_finding("reentrancy-eth"))
+        assert prob is not None
+        assert 0.0 <= prob <= 1.0
+
+    def test_unknown_class_returns_none(self):
+        provider = LocalAcceptancePatternProvider()
+        assert provider.acceptance_probability(_finding("nonexistent-check")) is None
+
+    def test_missing_data_file_degrades_gracefully(self, tmp_path):
+        provider = LocalAcceptancePatternProvider(data_path=str(tmp_path / "nope.json"))
+        assert provider.is_available() is False
+        assert provider.acceptance_probability(_finding("reentrancy-eth")) is None
+
+
+# --------------------------------------------------------------------------- #
+# Curated JSON data loads + validates
+# --------------------------------------------------------------------------- #
+class TestCuratedData:
+    def test_data_file_is_valid_and_well_formed(self):
+        with open(_DEFAULT_DATA_PATH, encoding="utf-8") as handle:
+            data = json.load(handle)
+        assert "_meta" in data and "provenance" in data["_meta"]
+        patterns = data["patterns"]
+        assert patterns
+        for key, entry in patterns.items():
+            assert isinstance(key, str)
+            prob = entry["acceptance_prob"]
+            assert 0.0 <= float(prob) <= 1.0, f"{key} prob out of range"
+
+
+# --------------------------------------------------------------------------- #
+# RECALL-SAFE proof: reorder-only, never drops (count in == count out)
+# --------------------------------------------------------------------------- #
+class TestRecallSafeOrdering:
+    def test_low_acceptance_finding_reordered_lower_but_never_removed(self):
+        # front_running has low acceptance; reentrancy has high acceptance.
+        results = [
+            {
+                "tool": "t",
+                "findings": [
+                    _finding("front-running"),  # low acceptance -> should sink
+                    _finding("reentrancy-eth"),  # high acceptance -> should rise
+                ],
+            }
+        ]
+        count_in = sum(len(r["findings"]) for r in results)
+        total = apply_acceptance_ordering(results, provider=LocalAcceptancePatternProvider())
+        count_out = sum(len(r["findings"]) for r in results)
+
+        # Nothing dropped — recall preserved.
+        assert count_in == count_out == 2
+        assert total == 2
+        ordered = results[0]["findings"]
+        # High-acceptance finding rose to the top; low-acceptance is still present.
+        assert ordered[0]["type"] == "reentrancy-eth"
+        assert ordered[1]["type"] == "front-running"
+        # Signal annotated on the finding, NOT removed from output.
+        assert "acceptance_prob" in ordered[0]
+        assert "acceptance_prob" in ordered[1]
+        assert ordered[0]["acceptance_prob"] > ordered[1]["acceptance_prob"]
+
+    def test_unknown_class_findings_kept_visible(self):
+        results = [
+            {
+                "tool": "t",
+                "findings": [
+                    _finding("reentrancy-eth"),
+                    _finding("totally-unknown-xyz"),  # unknown class -> no prob
+                ],
+            }
+        ]
+        apply_acceptance_ordering(results, provider=LocalAcceptancePatternProvider())
+        types = {f["type"] for f in results[0]["findings"]}
+        assert types == {"reentrancy-eth", "totally-unknown-xyz"}  # nothing dropped
+        # Unknown-class finding has no acceptance annotation.
+        unknown = next(f for f in results[0]["findings"] if f["type"] == "totally-unknown-xyz")
+        assert "acceptance_prob" not in unknown
+
+    def test_unavailable_provider_is_noop(self):
+        class _Down:
+            name = "down"
+
+            def is_available(self) -> bool:
+                return False
+
+            def list_vulnerability_patterns(self):
+                return {}
+
+            def acceptance_probability(self, finding, protocol_type=None):
+                return None
+
+        results = [{"tool": "t", "findings": [_finding("reentrancy-eth")]}]
+        total = apply_acceptance_ordering(results, provider=_Down())
+        assert total == -1
+        assert len(results[0]["findings"]) == 1  # untouched
+
+
+# --------------------------------------------------------------------------- #
+# External adapter — opt-in, SSRF-guarded, paid scan unimplemented
+# --------------------------------------------------------------------------- #
+class TestBugBountyProvider:
+    def test_unavailable_by_default(self, monkeypatch):
+        monkeypatch.delenv("MIESC_BUGBOUNTY_API_KEY", raising=False)
+        assert BugBountyIntelligenceProvider().is_available() is False
+
+    def test_allow_remote_false_blocks_even_when_configured(self, monkeypatch):
+        monkeypatch.setenv("MIESC_BUGBOUNTY_API_KEY", "secret")
+        provider = BugBountyIntelligenceProvider(
+            config={"enabled": True}, policy=AcceptancePolicy(allow_remote=False)
+        )
+        assert provider.is_available() is False
+
+    def test_available_when_env_and_config_and_remote_set(self, monkeypatch):
+        monkeypatch.setenv("MIESC_BUGBOUNTY_API_KEY", "secret")
+        provider = BugBountyIntelligenceProvider(
+            config={"enabled": True}, policy=AcceptancePolicy(allow_remote=True)
+        )
+        assert provider.is_available() is True
+
+    def test_network_call_goes_through_ssrf_guard_rejecting_localhost(self, monkeypatch):
+        monkeypatch.setenv("MIESC_BUGBOUNTY_API_KEY", "secret")
+        # Point the provider at a localhost/private URL — the SSRF guard must reject it,
+        # so no request is made and we get {} back (never raises).
+        provider = BugBountyIntelligenceProvider(
+            config={"enabled": True, "base_url": "http://127.0.0.1:9000"},
+            policy=AcceptancePolicy(allow_remote=True),
+        )
+
+        def _boom(*_a, **_k):  # pragma: no cover - must never be reached
+            raise AssertionError("urlopen called despite SSRF-blocked URL")
+
+        provider._opener = _boom
+        assert provider.list_vulnerability_patterns() == {}
+
+    def test_guarded_success_path_with_mocked_opener(self, monkeypatch):
+        monkeypatch.setenv("MIESC_BUGBOUNTY_API_KEY", "secret")
+        # Public HTTPS host that passes the guard; mock the opener so no real DNS/network.
+        provider = BugBountyIntelligenceProvider(
+            config={"enabled": True, "base_url": "https://intel.example.com"},
+            policy=AcceptancePolicy(allow_remote=True),
+        )
+        payload = json.dumps({"patterns": {"reentrancy": 0.9, "front_running": 0.1}}).encode()
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def read(self):
+                return payload
+
+        # Guard resolves DNS for non-allowlisted hosts; the base_url host IS allowlisted
+        # by the adapter, so no real DNS occurs. Opener is fully mocked.
+        provider._opener = lambda *_a, **_k: _Resp()
+        patterns = provider.list_vulnerability_patterns()
+        assert patterns["reentrancy"] == 0.9
+        prob = provider.acceptance_probability(_finding("reentrancy-eth"))
+        assert prob == 0.9
+
+    def test_paid_scan_is_not_implemented(self):
+        provider = BugBountyIntelligenceProvider()
+        with pytest.raises(NotImplementedError, match="opt-in extension point"):
+            provider.scan_contract("contract.sol")
+
+    def test_remote_disabled_returns_empty_without_calling(self):
+        provider = BugBountyIntelligenceProvider(
+            config={"enabled": True}, policy=AcceptancePolicy(allow_remote=False)
+        )
+        assert provider.list_vulnerability_patterns() == {}
+
+
+# --------------------------------------------------------------------------- #
+# Factory
+# --------------------------------------------------------------------------- #
+class TestFactory:
+    def test_returns_local_by_default(self):
+        provider = auto_acceptance_provider()
+        assert isinstance(provider, LocalAcceptancePatternProvider)
+
+    def test_falls_back_to_local_when_external_unavailable(self, monkeypatch):
+        monkeypatch.delenv("MIESC_BUGBOUNTY_API_KEY", raising=False)
+        provider = auto_acceptance_provider(
+            prefer_local=False,
+            config={"enabled": True},
+            policy=AcceptancePolicy(allow_remote=True),
+        )
+        # No API key -> external not available -> local fallback.
+        assert isinstance(provider, LocalAcceptancePatternProvider)
+
+    def test_returns_external_when_fully_enabled(self, monkeypatch):
+        monkeypatch.setenv("MIESC_BUGBOUNTY_API_KEY", "secret")
+        provider = auto_acceptance_provider(
+            prefer_local=False,
+            config={"enabled": True},
+            policy=AcceptancePolicy(allow_remote=True),
+        )
+        assert isinstance(provider, BugBountyIntelligenceProvider)
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring smoke
+# --------------------------------------------------------------------------- #
+class TestCliWiring:
+    def test_apply_acceptance_ordering_helper_local(self):
+        from miesc.cli.commands.scan import _apply_acceptance_ordering
+
+        results = [
+            {
+                "tool": "t",
+                "findings": [_finding("front-running"), _finding("reentrancy-eth")],
+            }
+        ]
+        _apply_acceptance_ordering(results, choice="local", quiet=True)
+        # Recall-safe: still two findings, reordered by acceptance.
+        assert len(results[0]["findings"]) == 2
+        assert results[0]["findings"][0]["type"] == "reentrancy-eth"
+
+    def test_scan_exposes_acceptance_provider_flag(self):
+        from miesc.cli.commands.scan import scan
+
+        opts = {p.name for p in scan.params}
+        assert "acceptance_provider" in opts


### PR DESCRIPTION
Closes #84 — adds "Bug Bounty Intelligence" style acceptance-pattern signal as a **pluggable interface**, NOT a coupling to any external service.

## Design (ports & adapters)
Per the maintainer's directive: the core defines an interface; external services are opt-in adapters. This keeps DPGA **platform-independence** (indicator 4) and **privacy** (indicator 7) intact — the core never requires any provider or network.

- **`miesc/core/acceptance_contracts.py`** — the port: `AcceptancePatternProvider` Protocol + `AcceptancePolicy(local_first=True, allow_remote=False)` (mirrors the shipped `ReasoningProvider` pattern). Finding→vuln-class via existing `finding_taxonomy.normalize_finding_type`.
- **`miesc/core/acceptance_providers.py`** — two adapters proving the abstraction:
  - `LocalAcceptancePatternProvider` — **default**, offline, always available, reads curated open data.
  - `BugBountyIntelligenceProvider` — **opt-in** external (issue #84's service). `is_available()` False unless policy `allow_remote=True` AND config `enabled=true` AND `MIESC_BUGBOUNTY_API_KEY` set. Network egress via `net_guard` SSRF guard. The paid x402 scan is a documented extension point (`NotImplementedError`), not shipped.
  - `auto_acceptance_provider(prefer_local=True)` factory.
- **`miesc/knowledge_base/acceptance_patterns.json`** — 16 curated class-level acceptance rates from public competitive-audit outcomes, with a provenance `_meta` block (does NOT reproduce any vendor corpus).

## Recall-safe (never drops)
The signal only **reorders** (annotates `finding['acceptance_prob']`, stable-sorts) — it is kept out of the `--min-confidence` drop path. Low-acceptance findings sink in rank but stay fully visible. Proven by `test_low_acceptance_finding_reordered_lower_but_never_removed` (count-in == count-out).

## Opt-in
`scan --acceptance-provider [none|local|bugbounty]`, default `none`. Local is free/offline; bugbounty needs explicit enable + key + `allow_remote`.

## Verification
- Full suite green + order-independent (random seed), ruff + black clean. (CI confirms.)
- No frozen paper evidence touched.

Any third party can implement `AcceptancePatternProvider` — holistis is simply the first external adapter.
