### PR TITLE
feat(verify): --poc emits Foundry PoC scaffolds (phase 3, completes counterexample→PoC)

### DIFF
--- a/miesc/cli/commands/verify.py
+++ b/miesc/cli/commands/verify.py
@@ -68,6 +68,12 @@ def _find_foundry_root(start: Path) -> Optional[Path]:
     default=None,
     help="Write the unified verification report as SARIF 2.1.0 (GitHub code scanning).",
 )
+@click.option(
+    "--poc",
+    type=click.Path(),
+    default=None,
+    help="Write a Foundry PoC test scaffold per counterexample into this directory.",
+)
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 def verify(
     contract_path: str,
@@ -77,6 +83,7 @@ def verify(
     timeout: int,
     output: str | None,
     sarif: str | None,
+    poc: str | None,
     quiet: bool,
 ) -> None:
     """Run formal-verification provers against a contract.
@@ -238,6 +245,15 @@ def verify(
     if sarif:
         report.to_sarif(sarif)
         success(f"SARIF report written to {sarif}")
+
+    # Write a Foundry PoC test scaffold per counterexample
+    if poc:
+        scaffolds = report.foundry_scaffolds(contract_name)
+        poc_dir = Path(poc)
+        poc_dir.mkdir(parents=True, exist_ok=True)
+        for filename, solidity in scaffolds:
+            (poc_dir / filename).write_text(solidity, encoding="utf-8")
+        success(f"Wrote {len(scaffolds)} PoC scaffold(s) to {poc}")
 
     # Exit code: 1 if any prover reported failures
     any_failed = any(r.status == "failed" for r in results.values())

--- a/miesc/formal/unified_report.py
+++ b/miesc/formal/unified_report.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from miesc.core.exporters import Finding, SARIFExporter
 
@@ -322,6 +322,22 @@ class UnifiedVerificationReport:
 
             Path(output_path).write_text(text, encoding="utf-8")
         return text
+
+    def foundry_scaffolds(self, contract_name: str = "Target") -> List[Tuple[str, str]]:
+        """Build a Foundry PoC scaffold for every counterexample across all provers.
+
+        Returns ``(filename, solidity)`` pairs and does no I/O, so the caller decides
+        where to write them. Filenames are unique (``<Contract>_<prover>_cx<n>.t.sol``).
+        """
+        base = re.sub(r"[^A-Za-z0-9]", "", contract_name) or "Target"
+        scaffolds: List[Tuple[str, str]] = []
+        counter = 0
+        for prover in self.provers:
+            for cex in prover.counterexamples:
+                counter += 1
+                filename = f"{base}_{cex.prover}_cx{counter}.t.sol"
+                scaffolds.append((filename, cex.to_foundry_scaffold(base)))
+        return scaffolds
 
     def to_sarif(self, output_path: Optional[str] = None) -> str:
         """Map violated properties / counterexamples to SARIF 2.1.0.

--- a/tests/test_counterexample_poc.py
+++ b/tests/test_counterexample_poc.py
@@ -12,7 +12,11 @@ from miesc.formal.counterexample_poc import (
     _infer_type_and_name,
     counterexample_to_foundry_test,
 )
-from miesc.formal.unified_report import Counterexample
+from miesc.formal.unified_report import (
+    Counterexample,
+    ProverVerdict,
+    UnifiedVerificationReport,
+)
 
 
 class TestTypeInference(unittest.TestCase):
@@ -99,6 +103,38 @@ class TestCounterexampleMethod(unittest.TestCase):
         out = cx.to_foundry_scaffold(contract_name="Bank")
         self.assertIn("contract BankCounterexamplePoC is Test", out)
         self.assertIn("uint256 amount = 7;", out)
+
+
+class TestReportScaffolds(unittest.TestCase):
+    def _report(self, *counterexamples):
+        verdict = ProverVerdict(
+            prover="halmos", status="violated", counterexamples=list(counterexamples)
+        )
+        return UnifiedVerificationReport(contract="Vault.sol", provers=[verdict])
+
+    def test_one_scaffold_per_counterexample_unique_names(self):
+        report = self._report(
+            Counterexample(prover="halmos", text="p_a_uint256 = 1"),
+            Counterexample(prover="halmos", text="p_b_uint256 = 2"),
+        )
+        scaffolds = report.foundry_scaffolds(contract_name="Vault")
+        self.assertEqual(len(scaffolds), 2)
+        names = [f for f, _ in scaffolds]
+        self.assertEqual(len(set(names)), 2)  # unique filenames
+        self.assertTrue(all(f.endswith(".t.sol") for f in names))
+        self.assertIn("uint256 a = 1;", scaffolds[0][1])
+
+    def test_no_counterexamples_yields_no_scaffolds(self):
+        report = UnifiedVerificationReport(
+            contract="X.sol", provers=[ProverVerdict(prover="halmos", status="verified")]
+        )
+        self.assertEqual(report.foundry_scaffolds(), [])
+
+    def test_filename_sanitized_from_contract_name(self):
+        report = self._report(Counterexample(prover="halmos", text="x = 1"))
+        fname = report.foundry_scaffolds(contract_name="My/Weird Name.sol")[0][0]
+        self.assertNotIn("/", fname)
+        self.assertNotIn(" ", fname)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Phase 3** wires the counterexample→PoC pipeline into the CLI, completing the arc (#100 structured assignments → #104 scaffold generator → this).

## What
`miesc verify <contract> --poc <dir>` writes **one Foundry test scaffold per counterexample** into `<dir>`. New `UnifiedVerificationReport.foundry_scaffolds(contract_name)` returns `(filename, solidity)` pairs — unique names `<Contract>_<prover>_cx<n>.t.sol`, **no I/O** so it stays unit-testable — and the command writes them.

```
$ miesc verify Vault.sol --poc ./pocs
  Wrote 2 PoC scaffold(s) to ./pocs
$ ls ./pocs
  Vault_halmos_cx1.t.sol  Vault_halmos_cx2.t.sol   # typed inputs from the witness, ready to complete
```

So a failing `miesc verify` now hands the developer runnable-shaped reproductions straight from the prover witnesses, instead of opaque counterexample strings.

## Tests / safety
`foundry_scaffolds`: one-per-counterexample, unique filenames, empty when no counterexamples, filename sanitized from contract name; the `--poc` flag registers. 44 poc/unified-report tests pass. ruff+black clean — **ruff (F823) caught a real bug**: a redundant local `from pathlib import Path` in the new block shadowed the module-level `Path` used earlier (would UnboundLocalError at runtime); removed it. Pure-Python, no new deps, no frozen artifacts. Sequencing merge on green CI.