### PR TITLE
feat(verify): --poc-check runs forge build on PoC scaffolds (phase 5)

### DIFF
--- a/miesc/cli/commands/verify.py
+++ b/miesc/cli/commands/verify.py
@@ -74,6 +74,12 @@ def _find_foundry_root(start: Path) -> Optional[Path]:
     default=None,
     help="Write a Foundry PoC test scaffold per counterexample into this directory.",
 )
+@click.option(
+    "--poc-check",
+    is_flag=True,
+    help="With --poc: run 'forge build' on each scaffold to confirm it compiles "
+    "(best-effort; skipped when forge is not installed).",
+)
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 def verify(
     contract_path: str,
@@ -84,6 +90,7 @@ def verify(
     output: str | None,
     sarif: str | None,
     poc: str | None,
+    poc_check: bool,
     quiet: bool,
 ) -> None:
     """Run formal-verification provers against a contract.
@@ -254,6 +261,18 @@ def verify(
         for filename, solidity in scaffolds:
             (poc_dir / filename).write_text(solidity, encoding="utf-8")
         success(f"Wrote {len(scaffolds)} PoC scaffold(s) to {poc}")
+
+        # Optionally confirm each scaffold compiles with forge (best-effort)
+        if poc_check:
+            from miesc.formal.poc_check import check_scaffolds_compile
+
+            repo_dir = str(Path(contract_path).resolve().parent)
+            checks = check_scaffolds_compile(scaffolds, repo_dir, contract_path)
+            for c in checks:
+                icon = {"compiled": "✓", "failed": "✗", "skipped": "-"}.get(c["status"], "?")
+                console.print(f"    {icon} {c['filename']}: {c['status']}")
+    elif poc_check:
+        info("--poc-check has no effect without --poc.")
 
     # Exit code: 1 if any prover reported failures
     any_failed = any(r.status == "failed" for r in results.values())

--- a/miesc/formal/poc_check.py
+++ b/miesc/formal/poc_check.py
@@ -1,0 +1,100 @@
+"""Optional ``forge build`` compile-check for generated PoC scaffolds (phase 5).
+
+Phase 4 makes the scaffolds *statically* compile-valid; this optionally runs the
+real ``forge build`` on each, so a project with Foundry installed can confirm the
+generated Solidity actually compiles. Strictly best-effort and opt-in: when forge
+is not on PATH (e.g. CI) or the project cannot be scaffolded, every scaffold is
+reported ``skipped`` and nothing runs — it never affects the default
+``verify --poc`` path.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+# A minimal forge-std test used to detect whether the environment can compile
+# forge-std at all (solc availability), separate from any generated scaffold.
+_BASELINE_PROBE = """// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+contract _MiescBaselineProbe is Test {
+    function test_baseline() public pure {}
+}
+"""
+
+
+def forge_available() -> bool:
+    """True if the ``forge`` binary is on PATH."""
+    return shutil.which("forge") is not None
+
+
+def _all_skipped(scaffolds: Sequence[Tuple[str, str]]) -> List[Dict[str, str]]:
+    return [{"filename": name, "status": "skipped"} for name, _ in scaffolds]
+
+
+def check_scaffolds_compile(
+    scaffolds: Sequence[Tuple[str, str]],
+    repo_dir: str,
+    contract_file: str,
+) -> List[Dict[str, str]]:
+    """Compile each ``(filename, solidity)`` scaffold via a temp Foundry project.
+
+    Returns one ``{"filename", "status"}`` per scaffold with status in
+    ``compiled | failed | skipped``. Each scaffold is built in isolation. This is
+    best-effort: it returns all ``skipped`` when forge is unavailable or the
+    project cannot be scaffolded, and never raises.
+    """
+    if not scaffolds:
+        return []
+    if not forge_available():
+        return _all_skipped(scaffolds)
+
+    try:
+        from miesc.poc.foundry_scaffold import scaffold_foundry_project
+        from miesc.poc.validators.foundry_runner import FoundryRunner
+    except Exception:
+        return _all_skipped(scaffolds)
+
+    try:
+        project = scaffold_foundry_project(Path(repo_dir), Path(contract_file))
+    except Exception:
+        project = None
+    if project is None:
+        return _all_skipped(scaffolds)
+
+    test_dir = Path(project) / "test"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    runner = FoundryRunner(project)
+
+    # Baseline probe: a trivial forge-std test. If even THIS cannot build (e.g. no
+    # installed solc matches forge-std's version requirement), the environment can't
+    # compile any scaffold that imports forge-std — that is an environment problem,
+    # not a scaffold problem, so report "skipped" rather than a misleading "failed".
+    probe = test_dir / "_MiescBaselineProbe.t.sol"
+    try:
+        probe.write_text(_BASELINE_PROBE, encoding="utf-8")
+        if not runner.compile():
+            return _all_skipped(scaffolds)
+    except Exception:
+        return _all_skipped(scaffolds)
+    finally:
+        if probe.exists():
+            probe.unlink()
+
+    results: List[Dict[str, str]] = []
+    for filename, solidity in scaffolds:
+        test_file = test_dir / filename
+        try:
+            test_file.write_text(solidity, encoding="utf-8")
+            compiled = bool(runner.compile())
+            results.append({"filename": filename, "status": "compiled" if compiled else "failed"})
+        except Exception:
+            results.append({"filename": filename, "status": "skipped"})
+        finally:
+            if test_file.exists():
+                test_file.unlink()
+    return results

--- a/tests/test_poc_check.py
+++ b/tests/test_poc_check.py
@@ -1,0 +1,84 @@
+"""Tests for the optional forge compile-check of PoC scaffolds (phase 5).
+
+The check must be strictly best-effort: skip everything when forge is absent
+(so CI is never affected), never raise, and report compiled/failed per scaffold
+when forge and the scaffolded project are available. The forge/Foundry
+collaborators are mocked so these run without forge installed.
+"""
+
+import unittest
+from unittest import mock
+
+from miesc.formal.poc_check import check_scaffolds_compile, forge_available
+
+_SCAFFOLDS = [("A_halmos_cx1.t.sol", "contract A {}"), ("B_halmos_cx2.t.sol", "contract B {}")]
+
+
+class TestForgeAvailability(unittest.TestCase):
+    def test_forge_available_reflects_path(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/forge"):
+            self.assertTrue(forge_available())
+        with mock.patch("shutil.which", return_value=None):
+            self.assertFalse(forge_available())
+
+
+class TestSkipPaths(unittest.TestCase):
+    def test_empty_scaffolds(self):
+        self.assertEqual(check_scaffolds_compile([], "/repo", "/c.sol"), [])
+
+    def test_all_skipped_when_forge_absent(self):
+        with mock.patch("miesc.formal.poc_check.forge_available", return_value=False):
+            out = check_scaffolds_compile(_SCAFFOLDS, "/repo", "/c.sol")
+        self.assertEqual([r["status"] for r in out], ["skipped", "skipped"])
+        self.assertEqual([r["filename"] for r in out], [s[0] for s in _SCAFFOLDS])
+
+    def test_all_skipped_when_project_scaffold_fails(self):
+        with (
+            mock.patch("miesc.formal.poc_check.forge_available", return_value=True),
+            mock.patch("miesc.poc.foundry_scaffold.scaffold_foundry_project", return_value=None),
+        ):
+            out = check_scaffolds_compile(_SCAFFOLDS, "/repo", "/c.sol")
+        self.assertTrue(all(r["status"] == "skipped" for r in out))
+
+
+class TestCompilePath(unittest.TestCase):
+    def test_reports_compiled_and_failed(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as project:
+            runner = mock.Mock()
+            # baseline build (True), then scaffold 1 compiles (True), scaffold 2 fails (False)
+            runner.compile.side_effect = [True, True, False]
+            with (
+                mock.patch("miesc.formal.poc_check.forge_available", return_value=True),
+                mock.patch(
+                    "miesc.poc.foundry_scaffold.scaffold_foundry_project", return_value=project
+                ),
+                mock.patch(
+                    "miesc.poc.validators.foundry_runner.FoundryRunner", return_value=runner
+                ),
+            ):
+                out = check_scaffolds_compile(_SCAFFOLDS, "/repo", "/c.sol")
+        self.assertEqual([r["status"] for r in out], ["compiled", "failed"])
+
+    def test_compile_exception_is_skipped_not_raised(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as project:
+            runner = mock.Mock()
+            runner.compile.side_effect = RuntimeError("forge blew up")
+            with (
+                mock.patch("miesc.formal.poc_check.forge_available", return_value=True),
+                mock.patch(
+                    "miesc.poc.foundry_scaffold.scaffold_foundry_project", return_value=project
+                ),
+                mock.patch(
+                    "miesc.poc.validators.foundry_runner.FoundryRunner", return_value=runner
+                ),
+            ):
+                out = check_scaffolds_compile([_SCAFFOLDS[0]], "/repo", "/c.sol")
+        self.assertEqual(out[0]["status"], "skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 5** — the optional, env-gated `forge build` check I deferred, done honestly.

## What
`miesc verify <contract> --poc <dir> --poc-check` runs `forge build` on each generated scaffold and reports `compiled | failed | skipped` per file. Reuses the existing `scaffold_foundry_project` + `FoundryRunner` (the exploit-validation infra).

## Strictly best-effort / never breaks CI
- No forge on PATH → every scaffold `skipped`, nothing runs. The default `--poc` path is untouched.
- **Environment vs scaffold failure**: a baseline forge-std probe is built first. If the env can't compile forge-std (e.g. no installed solc matches its `>=0.8.13,<0.9.0`), the check returns `skipped` — NOT a misleading `failed`. Only when the probe builds are per-scaffold `failed` results meaningful.
- Never raises; a compile exception → `skipped`.

## Verified for real
Ran the real path against **forge 1.3.5 locally**: it scaffolds the project, runs `forge build`, and correctly returned `skipped` on this box (its solc set doesn't satisfy forge-std) — exactly the env-honesty the baseline probe provides. 6 mocked tests keep CI forge-free (forge-unavailable→skip, project-scaffold-fail→skip, compiled/failed reporting, exception→skip). 67 formal-arc tests pass. ruff+black clean, no frozen artifacts.

This completes the counterexample→PoC arc (phases 1–5): structured witness → typed compile-valid scaffold → `verify --poc` → optional real forge check. Sequencing merge on green CI.