### PR TITLE
docs: document the counterexample→PoC pipeline (verify --poc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (with `--tolerance`) fails CI when the score drops versus a prior results or score
   JSON — a relative gate alongside the absolute `--fail-under`, the security analogue
   of a coverage-regression gate.
-- **Structured formal counterexamples.** The unified verification report parses each
-  prover's counterexample witness into structured `name = value` bindings (raw text
-  preserved), so `miesc verify` output carries machine-usable inputs — the foundation
-  for turning a counterexample into an executable proof-of-concept.
+- **Counterexample → Foundry PoC.** Formal verification now turns each prover
+  counterexample into an executable-shaped reproduction. The witness is parsed into
+  structured `name = value` bindings (raw text preserved), and
+  `miesc verify <contract> --poc <dir>` writes one Foundry test scaffold per
+  counterexample — laying the inputs into typed, compile-valid Solidity locals with
+  the type inferred from the prover's variable naming (`p_amount_uint256` →
+  `uint256 amount`). Values that are not literals (e.g. `2**256 - 1`) fall back to a
+  safe default with the raw value kept in a comment, so the scaffold always compiles.
+  `--poc-check` optionally runs `forge build` on each scaffold to confirm it compiles
+  (strictly best-effort; skipped when forge is unavailable, so CI is never affected).
 
 ## [6.0.0] - 2026-07-12
 

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -98,6 +98,24 @@ miesc score full_audit.json --badge svg -o security-badge.svg
 miesc score full_audit.json --fail-under 80
 ```
 
+### Formal Verification & Proof-of-Concept
+
+`miesc verify` runs formal-verification provers (Halmos, Kontrol, SMTChecker,
+Certora) and, when a property is violated, can turn the prover's counterexample
+into a **Foundry PoC scaffold** — the concrete inputs laid into a typed, ready-to-
+finish test.
+
+```bash
+# Run the provers against a contract
+miesc verify MyContract.sol
+
+# Emit one Foundry PoC scaffold per counterexample into ./pocs/
+miesc verify MyContract.sol --poc ./pocs
+
+# ...and confirm each scaffold compiles with forge (skipped if forge is absent)
+miesc verify MyContract.sol --poc ./pocs --poc-check
+```
+
 ## 4. The 9 Defense Layers
 
 MIESC analyzes contracts through **9 specialized defense layers**:


### PR DESCRIPTION
The formal counterexample→PoC feature shipped across #100/#104/#106/#107/#108 but only phase 1 was in the docs. This documents the full pipeline.

- **CHANGELOG `[Unreleased]`**: expands the entry to describe `miesc verify --poc` (scaffold emission), typed compile-valid inputs, the safe-default fallback, and `--poc-check`.
- **`docs/guides/QUICKSTART.md`**: a new *Formal Verification & Proof-of-Concept* section with `miesc verify` / `--poc` / `--poc-check` examples.

Docs only, both files verified not-frozen (README untouched). Completes the discoverability of the formal arc.