### PR TITLE
Bench v6.0.0 SmartBugs evidence and Solidity SDDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ benchmarks/results/evmbench/*
 !benchmarks/results/v5.1.6_deep_audit_rekt_report.md
 !benchmarks/results/v5.1.6_fp_dataset_pilot.md
 !benchmarks/results/v5.1.7_gates_report.md
+!benchmarks/results/v6.0.0_benchmark_report_20260811.md
 !benchmarks/results/evmbench/evmbench_ensemble_40.json
 !benchmarks/results/evmbench/evmbench_static_40.json
 data/benchmark_history/

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ benchmarks/results/evmbench/*
 !benchmarks/results/v5.1.6_fp_dataset_pilot.md
 !benchmarks/results/v5.1.7_gates_report.md
 !benchmarks/results/v6.0.0_benchmark_report_20260811.md
+!benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
 !benchmarks/results/evmbench/evmbench_ensemble_40.json
 !benchmarks/results/evmbench/evmbench_static_40.json
 data/benchmark_history/

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ benchmarks/results/evmbench/*
 !benchmarks/results/v5.1.7_gates_report.md
 !benchmarks/results/v6.0.0_benchmark_report_20260811.md
 !benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
+!benchmarks/results/extended_exploit_eval_20260811_120407.json
 !benchmarks/results/evmbench/evmbench_ensemble_40.json
 !benchmarks/results/evmbench/evmbench_static_40.json
 data/benchmark_history/

--- a/benchmarks/results/extended_exploit_eval_20260811_120407.json
+++ b/benchmarks/results/extended_exploit_eval_20260811_120407.json
@@ -1,0 +1,67 @@
+{
+  "timestamp": "20260811_120407",
+  "miesc_version": "6.0.0",
+  "dataset": "DeFiHackLabs (auto-classified)",
+  "sample_size": 96,
+  "total_available": 397,
+  "tools": [
+    "slither",
+    "aderyn"
+  ],
+  "execution_time_seconds": 168.23,
+  "metrics": {
+    "precision": 0.0,
+    "recall": 0.0,
+    "f1_score": 0,
+    "tp": 0,
+    "fp": 3,
+    "fn": 96
+  },
+  "by_vulnerability": {
+    "flash_loan": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 15
+    },
+    "oracle_manipulation": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 15
+    },
+    "unchecked_calls": {
+      "tp": 0,
+      "fp": 2,
+      "fn": 0
+    },
+    "front_running": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 4
+    },
+    "delegation": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 15
+    },
+    "access_control": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 15
+    },
+    "reentrancy": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 15
+    },
+    "time_manipulation": {
+      "tp": 0,
+      "fp": 1,
+      "fn": 15
+    },
+    "arithmetic": {
+      "tp": 0,
+      "fp": 0,
+      "fn": 2
+    }
+  }
+}

--- a/benchmarks/results/smartbugs_fp_filter_effect_20260811.json
+++ b/benchmarks/results/smartbugs_fp_filter_effect_20260811.json
@@ -1,0 +1,2787 @@
+{
+  "experiment": "smartbugs_fp_filter_effect",
+  "generated_utc": "2026-08-11T14:23:02.924869+00:00",
+  "note": "ADDITIVE experiment, not part of frozen paper evidence. Same detectors (Slither+Aderyn+SmartBugs), same ground truth, same match_findings scoring as smartbugs_evaluation.py. Only added step: production FalsePositiveFilter (strictness=medium, use_rag=False), dropping findings where fr.is_likely_fp, exactly as `miesc scan` does. Measures what the shipped product actually returns.",
+  "raw_baseline": {
+    "tp": 193,
+    "fp": 1263,
+    "fn": 39,
+    "precision": 0.1326,
+    "recall": 0.8319,
+    "f1": 0.2287
+  },
+  "filtered_production": {
+    "tp": 193,
+    "fp": 1056,
+    "fn": 39,
+    "precision": 0.1545,
+    "recall": 0.8319,
+    "f1": 0.2606
+  },
+  "delta": {
+    "fps_removed": 207,
+    "tps_lost": 0,
+    "precision_gain": 0.0219,
+    "recall_change": 0.0
+  },
+  "per_category": {
+    "access_control": {
+      "raw": {
+        "tp": 18,
+        "fp": 27,
+        "fn": 12,
+        "precision": 0.4,
+        "recall": 0.6,
+        "f1": 0.48
+      },
+      "filtered": {
+        "tp": 18,
+        "fp": 27,
+        "fn": 12,
+        "precision": 0.4,
+        "recall": 0.6,
+        "f1": 0.48
+      }
+    },
+    "arithmetic": {
+      "raw": {
+        "tp": 20,
+        "fp": 18,
+        "fn": 4,
+        "precision": 0.5263,
+        "recall": 0.8333,
+        "f1": 0.6452
+      },
+      "filtered": {
+        "tp": 20,
+        "fp": 7,
+        "fn": 4,
+        "precision": 0.7407,
+        "recall": 0.8333,
+        "f1": 0.7843
+      }
+    },
+    "bad_randomness": {
+      "raw": {
+        "tp": 29,
+        "fp": 29,
+        "fn": 5,
+        "precision": 0.5,
+        "recall": 0.8529,
+        "f1": 0.6304
+      },
+      "filtered": {
+        "tp": 29,
+        "fp": 16,
+        "fn": 5,
+        "precision": 0.6444,
+        "recall": 0.8529,
+        "f1": 0.7342
+      }
+    },
+    "denial_of_service": {
+      "raw": {
+        "tp": 6,
+        "fp": 6,
+        "fn": 10,
+        "precision": 0.5,
+        "recall": 0.375,
+        "f1": 0.4286
+      },
+      "filtered": {
+        "tp": 6,
+        "fp": 6,
+        "fn": 10,
+        "precision": 0.5,
+        "recall": 0.375,
+        "f1": 0.4286
+      }
+    },
+    "front_running": {
+      "raw": {
+        "tp": 6,
+        "fp": 2,
+        "fn": 1,
+        "precision": 0.75,
+        "recall": 0.8571,
+        "f1": 0.8
+      },
+      "filtered": {
+        "tp": 6,
+        "fp": 2,
+        "fn": 1,
+        "precision": 0.75,
+        "recall": 0.8571,
+        "f1": 0.8
+      }
+    },
+    "other": {
+      "raw": {
+        "tp": 0,
+        "fp": 0,
+        "fn": 5,
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": 0.0
+      },
+      "filtered": {
+        "tp": 0,
+        "fp": 0,
+        "fn": 5,
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": 0.0
+      }
+    },
+    "reentrancy": {
+      "raw": {
+        "tp": 32,
+        "fp": 909,
+        "fn": 0,
+        "precision": 0.034,
+        "recall": 1.0,
+        "f1": 0.0658
+      },
+      "filtered": {
+        "tp": 32,
+        "fp": 729,
+        "fn": 0,
+        "precision": 0.042,
+        "recall": 1.0,
+        "f1": 0.0807
+      }
+    },
+    "short_addresses": {
+      "raw": {
+        "tp": 1,
+        "fp": 0,
+        "fn": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "f1": 1.0
+      },
+      "filtered": {
+        "tp": 1,
+        "fp": 0,
+        "fn": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "f1": 1.0
+      }
+    },
+    "time_manipulation": {
+      "raw": {
+        "tp": 6,
+        "fp": 12,
+        "fn": 2,
+        "precision": 0.3333,
+        "recall": 0.75,
+        "f1": 0.4615
+      },
+      "filtered": {
+        "tp": 6,
+        "fp": 12,
+        "fn": 2,
+        "precision": 0.3333,
+        "recall": 0.75,
+        "f1": 0.4615
+      }
+    },
+    "unchecked_low_level_calls": {
+      "raw": {
+        "tp": 75,
+        "fp": 260,
+        "fn": 0,
+        "precision": 0.2239,
+        "recall": 1.0,
+        "f1": 0.3659
+      },
+      "filtered": {
+        "tp": 75,
+        "fp": 257,
+        "fn": 0,
+        "precision": 0.2259,
+        "recall": 1.0,
+        "f1": 0.3686
+      }
+    }
+  },
+  "per_contract": [
+    {
+      "path": "dataset/access_control/FibonacciBalance.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        7,
+        1
+      ],
+      "filtered": [
+        1,
+        7,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 18,
+      "kept": 8
+    },
+    {
+      "path": "dataset/access_control/arbitrary_location_write_simple.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        2,
+        1
+      ],
+      "filtered": [
+        1,
+        2,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 10,
+      "kept": 4
+    },
+    {
+      "path": "dataset/access_control/incorrect_constructor_name1.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/incorrect_constructor_name2.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/incorrect_constructor_name3.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/mapping_write.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 4
+    },
+    {
+      "path": "dataset/access_control/multiowned_vulnerable.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/mycontract.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        4,
+        0
+      ],
+      "filtered": [
+        1,
+        4,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 5
+    },
+    {
+      "path": "dataset/access_control/parity_wallet_bug_1.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        4,
+        2
+      ],
+      "filtered": [
+        1,
+        4,
+        2
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 22,
+      "kept": 22
+    },
+    {
+      "path": "dataset/access_control/parity_wallet_bug_2.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 17,
+      "kept": 17
+    },
+    {
+      "path": "dataset/access_control/phishable.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        4,
+        0
+      ],
+      "filtered": [
+        1,
+        4,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 9,
+      "kept": 6
+    },
+    {
+      "path": "dataset/access_control/proxy.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 2
+    },
+    {
+      "path": "dataset/access_control/rubixi.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        1
+      ],
+      "filtered": [
+        1,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 12
+    },
+    {
+      "path": "dataset/access_control/simple_suicide.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        1
+      ],
+      "filtered": [
+        1,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/unprotected0.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/access_control/wallet_02_refund_nosub.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 4
+    },
+    {
+      "path": "dataset/access_control/wallet_03_wrong_constructor.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 5
+    },
+    {
+      "path": "dataset/access_control/wallet_04_confused_sign.sol",
+      "category": "access_control",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 4
+    },
+    {
+      "path": "dataset/arithmetic/BECToken.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        2,
+        1
+      ],
+      "filtered": [
+        1,
+        2,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 14,
+      "kept": 14
+    },
+    {
+      "path": "dataset/arithmetic/insecure_transfer.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        1,
+        0
+      ],
+      "filtered": [
+        1,
+        1,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_1.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_add.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_benign_1.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_mapping_sym_1.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_minimal.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_mul.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_multitx_multifunc_feasible.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        1,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 1,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/integer_overflow_multitx_onefunc_feasible.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        1,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 1,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/overflow_simple_add.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        8,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 8,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 1
+    },
+    {
+      "path": "dataset/arithmetic/overflow_single_tx.sol",
+      "category": "arithmetic",
+      "raw": [
+        6,
+        1,
+        0
+      ],
+      "filtered": [
+        6,
+        0,
+        0
+      ],
+      "fps_removed": 1,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 6
+    },
+    {
+      "path": "dataset/arithmetic/timelock.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        2,
+        0
+      ],
+      "filtered": [
+        1,
+        2,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/arithmetic/token.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/arithmetic/tokensalechallenge.sol",
+      "category": "arithmetic",
+      "raw": [
+        1,
+        1,
+        2
+      ],
+      "filtered": [
+        1,
+        1,
+        2
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/bad_randomness/blackjack.sol",
+      "category": "bad_randomness",
+      "raw": [
+        3,
+        0,
+        0
+      ],
+      "filtered": [
+        3,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 17,
+      "kept": 17
+    },
+    {
+      "path": "dataset/bad_randomness/etheraffle.sol",
+      "category": "bad_randomness",
+      "raw": [
+        5,
+        0,
+        1
+      ],
+      "filtered": [
+        5,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 22,
+      "kept": 22
+    },
+    {
+      "path": "dataset/bad_randomness/guess_the_random_number.sol",
+      "category": "bad_randomness",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/bad_randomness/lottery.sol",
+      "category": "bad_randomness",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/bad_randomness/lucky_doubler.sol",
+      "category": "bad_randomness",
+      "raw": [
+        1,
+        0,
+        4
+      ],
+      "filtered": [
+        1,
+        0,
+        4
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/bad_randomness/old_blockhash.sol",
+      "category": "bad_randomness",
+      "raw": [
+        1,
+        6,
+        0
+      ],
+      "filtered": [
+        1,
+        2,
+        0
+      ],
+      "fps_removed": 4,
+      "tps_lost": 0,
+      "detected": 6,
+      "kept": 3
+    },
+    {
+      "path": "dataset/bad_randomness/random_number_generator.sol",
+      "category": "bad_randomness",
+      "raw": [
+        4,
+        9,
+        0
+      ],
+      "filtered": [
+        4,
+        0,
+        0
+      ],
+      "fps_removed": 9,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 9
+    },
+    {
+      "path": "dataset/bad_randomness/smart_billions.sol",
+      "category": "bad_randomness",
+      "raw": [
+        12,
+        14,
+        0
+      ],
+      "filtered": [
+        12,
+        14,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 80,
+      "kept": 80
+    },
+    {
+      "path": "dataset/denial_of_service/auction.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/denial_of_service/dos_address.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        1,
+        3
+      ],
+      "filtered": [
+        1,
+        1,
+        3
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 2
+    },
+    {
+      "path": "dataset/denial_of_service/dos_number.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        0,
+        4
+      ],
+      "filtered": [
+        1,
+        0,
+        4
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 1
+    },
+    {
+      "path": "dataset/denial_of_service/dos_simple.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        0,
+        1
+      ],
+      "filtered": [
+        1,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 1
+    },
+    {
+      "path": "dataset/denial_of_service/list_dos.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        0,
+        2
+      ],
+      "filtered": [
+        1,
+        0,
+        2
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 18,
+      "kept": 18
+    },
+    {
+      "path": "dataset/denial_of_service/send_loop.sol",
+      "category": "denial_of_service",
+      "raw": [
+        1,
+        5,
+        0
+      ],
+      "filtered": [
+        1,
+        5,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 5
+    },
+    {
+      "path": "dataset/front_running/ERC20.sol",
+      "category": "front_running",
+      "raw": [
+        2,
+        1,
+        0
+      ],
+      "filtered": [
+        2,
+        1,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 13,
+      "kept": 9
+    },
+    {
+      "path": "dataset/front_running/FindThisHash.sol",
+      "category": "front_running",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 6,
+      "kept": 2
+    },
+    {
+      "path": "dataset/front_running/eth_tx_order_dependence_minimal.sol",
+      "category": "front_running",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/front_running/odds_and_evens.sol",
+      "category": "front_running",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/other/crypto_roulette.sol",
+      "category": "other",
+      "raw": [
+        0,
+        0,
+        3
+      ],
+      "filtered": [
+        0,
+        0,
+        3
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 7
+    },
+    {
+      "path": "dataset/other/name_registrar.sol",
+      "category": "other",
+      "raw": [
+        0,
+        0,
+        1
+      ],
+      "filtered": [
+        0,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 0,
+      "kept": 0
+    },
+    {
+      "path": "dataset/other/open_address_lottery.sol",
+      "category": "other",
+      "raw": [
+        0,
+        0,
+        1
+      ],
+      "filtered": [
+        0,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/0x01f8c4e3fa3edeb29e514cba738d87ce8c091d3f.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x23a91059fdc9579a9fbd0edc5f2ea0bfdb70deb4.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x4320e6f8c05b27ab4707cd1f6d5ce6f3e4b3a5a1.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x4e73b32ed6c35f570686b89848e5f39f20ecc106.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x561eac93c92360949ab1f1403323e6db345cbf31.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x627fa62ccbb1c1b04ffaecd72a53e37fc0e17839.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 7
+    },
+    {
+      "path": "dataset/reentrancy/0x7541b76cb60f4c60af330c208b0623b7f54bf615.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        76,
+        0
+      ],
+      "filtered": [
+        1,
+        48,
+        0
+      ],
+      "fps_removed": 28,
+      "tps_lost": 0,
+      "detected": 27,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/0x7a8721a9d64c74da899424c1b52acbf58ddc9782.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/reentrancy/0x7b368c4e805c3870b6c49a3f1f49f69af8662cf3.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        76,
+        0
+      ],
+      "filtered": [
+        1,
+        48,
+        0
+      ],
+      "fps_removed": 28,
+      "tps_lost": 0,
+      "detected": 27,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/0x8c7777c45481dba411450c228cb692ac3d550344.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x93c32845fae42c83a70e5f06214c8433665c2ab5.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        76,
+        0
+      ],
+      "filtered": [
+        1,
+        48,
+        0
+      ],
+      "fps_removed": 28,
+      "tps_lost": 0,
+      "detected": 27,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/0x941d225236464a25eb18076df7da6a91d0f95e9e.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0x96edbe868531bd23a6c05e9d0c424ea64fb1b78b.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/reentrancy/0xaae1f51cf3339f18b6d3f3bdc75a5facd744b0b8.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0xb5e1b1ee15c6fa0e48fce100125569d430f1bd12.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0xb93430ce38ac4a6bb47fb1fc085ea669353fd89e.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0xbaf51e761510c1a11bf48dd87c0307ac8a8c8a4f.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/0xbe4041d55db380c5ae9d4a9b9703f1ed4e7e3888.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/reentrancy/0xcead721ef5b11f1a7b530171aab69b16c5e66b6e.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        52,
+        0
+      ],
+      "filtered": [
+        1,
+        48,
+        0
+      ],
+      "fps_removed": 4,
+      "tps_lost": 0,
+      "detected": 26,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/0xf015c35649c82f5467c9c74b7f28ee67665aad68.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        76,
+        0
+      ],
+      "filtered": [
+        1,
+        48,
+        0
+      ],
+      "fps_removed": 28,
+      "tps_lost": 0,
+      "detected": 27,
+      "kept": 8
+    },
+    {
+      "path": "dataset/reentrancy/etherbank.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/reentrancy/etherstore.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/modifier_reentrancy.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        34,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 31,
+      "tps_lost": 0,
+      "detected": 10,
+      "kept": 6
+    },
+    {
+      "path": "dataset/reentrancy/reentrance.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/reentrancy/reentrancy_bonus.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/reentrancy/reentrancy_cross_function.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/reentrancy/reentrancy_dao.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 6,
+      "kept": 6
+    },
+    {
+      "path": "dataset/reentrancy/reentrancy_insecure.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        13,
+        0
+      ],
+      "filtered": [
+        1,
+        6,
+        0
+      ],
+      "fps_removed": 7,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 3
+    },
+    {
+      "path": "dataset/reentrancy/reentrancy_simple.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/reentrancy/simple_dao.sol",
+      "category": "reentrancy",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/reentrancy/spank_chain_payment.sol",
+      "category": "reentrancy",
+      "raw": [
+        2,
+        506,
+        0
+      ],
+      "filtered": [
+        2,
+        480,
+        0
+      ],
+      "fps_removed": 26,
+      "tps_lost": 0,
+      "detected": 183,
+      "kept": 97
+    },
+    {
+      "path": "dataset/short_addresses/short_address_example.sol",
+      "category": "short_addresses",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/time_manipulation/ether_lotto.sol",
+      "category": "time_manipulation",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 4
+    },
+    {
+      "path": "dataset/time_manipulation/governmental_survey.sol",
+      "category": "time_manipulation",
+      "raw": [
+        1,
+        1,
+        1
+      ],
+      "filtered": [
+        1,
+        1,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 6,
+      "kept": 6
+    },
+    {
+      "path": "dataset/time_manipulation/lottopollo.sol",
+      "category": "time_manipulation",
+      "raw": [
+        1,
+        0,
+        1
+      ],
+      "filtered": [
+        1,
+        0,
+        1
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/time_manipulation/roulette.sol",
+      "category": "time_manipulation",
+      "raw": [
+        2,
+        8,
+        0
+      ],
+      "filtered": [
+        2,
+        8,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 10
+    },
+    {
+      "path": "dataset/time_manipulation/timed_crowdsale.sol",
+      "category": "time_manipulation",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 4,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x07f7ecb66d788ab01dc93b9b71a88401de7d0f2e.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        14,
+        0
+      ],
+      "filtered": [
+        2,
+        14,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 33,
+      "kept": 23
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x0cbe050f75bc8f8c2d6c0d249fea125fd6e1acc9.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x19cf8481ea15427a98ba3cdd6d9e14690011ab10.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 42,
+      "kept": 42
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x2972d548497286d18e92b5fa1f8f9139e5653fd2.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        8,
+        0
+      ],
+      "filtered": [
+        1,
+        8,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x39cfd754c85023648bf003bea2dd498c5612abfa.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x3a0e9acd953ffc0dd18d63603488846a6b8b2b01.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x3e013fc32a54c4c5b6991ba539dcd0ec4355c859.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x3f2ef511aa6e75231e4deafc7a3d2ecab3741de2.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x4051334adc52057aca763453820cb0e045076ef3.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        8,
+        0
+      ],
+      "filtered": [
+        1,
+        8,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x4a66ad0bca2d700f11e1f2fc2c106f7d3264504c.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x4b71ad9c1a84b9b643aa54fdd66e2dec96e8b152.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        8,
+        0
+      ],
+      "filtered": [
+        1,
+        8,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x524960d55174d912768678d8c606b4d50b79d7b1.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x52d2e0f9b01101a59b38a3d05c80b7618aeed984.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 6,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x5aa88d2901c68fda244f1d0584400368d2c8e739.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x610495793564aed0f9c7fc48dc4c7c9151d34fd6.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 4
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x627fa62ccbb1c1b04ffaecd72a53e37fc0e17839.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 7
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x663e4229142a27f00bafb5d087e1e730648314c3.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        3,
+        81,
+        0
+      ],
+      "filtered": [
+        3,
+        81,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 248,
+      "kept": 116
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x70f9eddb3931491aab1aeafbc1e7f1ca2a012db4.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x78c2a1e91b52bca4130b6ed9edd9fbcfd4671c37.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x7a4349a749e59a5736efb7826ee3496a2dfd5489.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x7d09edb07d23acb532a82be3da5c17d9d85806b4.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        14,
+        0
+      ],
+      "filtered": [
+        2,
+        14,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 34,
+      "kept": 24
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x806a6bd219f162442d992bdc4ee6eba1f2c5a707.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x84d9ec85c9c568eb332b7226a8f826d897e0a4a8.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x89c1b3807d4c67df034fffb62f3509561218d30b.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        4,
+        0,
+        0
+      ],
+      "filtered": [
+        4,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 11,
+      "kept": 11
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x8fd1e427396ddb511533cf9abdbebd0a7e08da35.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x958a8f594101d2c0485a52319f29b2647f2ebc06.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0x9d06cbafa865037a01d322d3f4222fa3e04e5488.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        25,
+        0
+      ],
+      "filtered": [
+        2,
+        25,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 22,
+      "kept": 7
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xa1fceeff3acc57d257b917e30c4df661401d6431.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xa46edd6a9a93feec36576ee5048146870ea2c3ae.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xb0510d68f210b7db66e8c7c814f22680f2b8d1d6.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        5,
+        13,
+        0
+      ],
+      "filtered": [
+        5,
+        13,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 30,
+      "kept": 15
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xb11b2fed6c9354f7aa2f658d3b4d7b31d8a13b77.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 18,
+      "kept": 9
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xb37f18af15bafb869a065b61fc83cfc44ed9cc27.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 10,
+      "kept": 4
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xb620cee6b52f96f3c6b253e6eea556aa2d214a99.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        3,
+        11,
+        0
+      ],
+      "filtered": [
+        3,
+        11,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 31,
+      "kept": 18
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xb7c5c5aa4d42967efe906e1b66cb8df9cebf04f7.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        4,
+        0
+      ],
+      "filtered": [
+        1,
+        4,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 10,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xbaa3de6504690efb064420d89e871c27065cdd52.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 18,
+      "kept": 9
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xbebbfe5b549f5db6e6c78ca97cac19d1fb03082c.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        3,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 18,
+      "kept": 9
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xd2018bfaa266a9ec0a1a84b061640faa009def76.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xd5967fed03e85d1cce44cab284695b41bc675b5c.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        8,
+        0
+      ],
+      "filtered": [
+        1,
+        8,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 12,
+      "kept": 6
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xdb1c55f6926e7d847ddf8678905ad871a68199d2.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xe09b1ab8111c2729a76f16de96bc86a7af837928.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        31,
+        0
+      ],
+      "filtered": [
+        1,
+        31,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 61,
+      "kept": 50
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xe4eabdca81e31d9acbc4af76b30f532b6ed7f3bf.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xe82f0742a71a02b9e9ffc142fdcb6eb1ed06fb87.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xe894d54dca59cb53fe9cbc5155093605c7068220.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        9,
+        0
+      ],
+      "filtered": [
+        1,
+        9,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 14,
+      "kept": 7
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xec329ffc97d75fe03428ae155fc7793431487f63.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 5
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xf2570186500a46986f3139f65afedc2afe4f445d.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xf29ebe930a539a60279ace72c707cba851a57707.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        5,
+        0
+      ],
+      "filtered": [
+        1,
+        5,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 5,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/0xf70d589d76eebdd7c12cc5eec99f8f6fa4233b9e.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 1,
+      "kept": 1
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/etherpot_lotto.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 11,
+      "kept": 11
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/king_of_the_ether_throne.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        4,
+        0,
+        0
+      ],
+      "filtered": [
+        4,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 8,
+      "kept": 8
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/lotto.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        2,
+        0,
+        0
+      ],
+      "filtered": [
+        2,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 3,
+      "kept": 3
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/mishandled.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        0,
+        0
+      ],
+      "filtered": [
+        1,
+        0,
+        0
+      ],
+      "fps_removed": 0,
+      "tps_lost": 0,
+      "detected": 2,
+      "kept": 2
+    },
+    {
+      "path": "dataset/unchecked_low_level_calls/unchecked_return_value.sol",
+      "category": "unchecked_low_level_calls",
+      "raw": [
+        1,
+        6,
+        0
+      ],
+      "filtered": [
+        1,
+        3,
+        0
+      ],
+      "fps_removed": 3,
+      "tps_lost": 0,
+      "detected": 7,
+      "kept": 3
+    }
+  ],
+  "total_time_s": 286.3,
+  "contracts_evaluated": 143
+}

--- a/benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
+++ b/benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
@@ -1,0 +1,238 @@
+# MIESC v6.0.0 — Real-World Exploit Arena (DeFiHackLabs)
+
+**Date**: 2026-08-11
+**Run type**: Additive benchmark (no frozen paper artifact modified — see §6).
+**Worktree**: `/Users/fboiero/Documents/GitHub/MIESC-main` (branch `bench/v6.0.0-smartbugs`).
+**Machine**: macOS (darwin 25.4.0), single machine, Python 3.14.5.
+
+This is the **"arena grande"** — MIESC v6.0.0 run against a large set of
+real-world DeFi exploit PoCs from **DeFiHackLabs** (SunWeb3Sec), the companion to
+the academic SmartBugs-Curated benchmark (`v6.0.0_benchmark_report_20260811.md`).
+Every number here is the **real measured output** of the harness. The headline is
+not flattering, and the reason is a **methodological one that this report makes
+explicit** rather than hiding behind a percentage.
+
+---
+
+## 1. Dataset
+
+| Field | Value |
+|-------|-------|
+| Source | `https://github.com/SunWeb3Sec/DeFiHackLabs` |
+| Clone commit | `2c99b565ae24ea2006adf181da20c4419b3edc30` (2026-08-10) |
+| Fetch command | `python3 benchmarks/build_datasets.py --rekt` |
+| `.sol` files in repo | 895 |
+| Filtered "exploit" contracts | 798 |
+| Copied into dataset (cap 500) | 497 → `data/datasets/rekt_exploits/contracts/*.sol` |
+| Ground-truth labels | `data/datasets/rekt_exploits/exploits_auto_classified.json` (frozen Jul-12, v2.0.0) |
+| Labeled exploits (total) | 496 (`flash_loan` 175, `unknown` 99, `reentrancy` 86, `time_manipulation` 65, `delegation` 23, `access_control` 21, `oracle_manipulation` 21, `front_running` 4, `arithmetic` 2) |
+| Classified (non-`unknown`) | 397 |
+| Label method (per the JSON's own `methodology`) | *"Vulnerability type auto-detected from code patterns (regex). Confidence: moderate. Manual review recommended for publication."* |
+
+### 1.1 What these files actually are (critical for reading every number below)
+
+DeFiHackLabs PoCs are **Foundry fork-tests**, not victim contracts. A typical
+file (`0vix_exp.sol`) begins:
+
+```solidity
+import "forge-std/Test.sol";
+import { ICErc20Delegate, IERC20, IUnitroller, IAaveFlashloan, ... } from "./../interface.sol";
+```
+
+The exploit *reproduces* an attack by **forking mainnet and calling the deployed
+victim through interfaces** (by on-chain address). Two consequences follow, and
+they govern the entire result:
+
+1. **The vulnerable victim source is NOT in the file.** It lives on-chain and is
+   referenced only via `interface` declarations + addresses. There is no victim
+   Solidity for a static analyzer to inspect.
+2. **The label is a regex keyword-count on the *attack* text**, not a verified
+   property of the victim. `0vix` is labeled `flash_loan` because
+   `detected_patterns` counted the word "flash" 3× in the PoC — not because a
+   detector confirmed a flash-loan bug in a specific contract.
+
+Of the 397 classified exploits, **325 resolve** to a copied file on this clone;
+**72 do not** (DeFiHackLabs grew/renamed files since the Jul-12 frozen labels).
+The harness counts a missing file as an automatic FN.
+
+---
+
+## 2. The arena as-run (harness verbatim)
+
+**Command**: `python3 benchmarks/evaluate_extended_exploits.py --sample 120 --save`
+**Tools**: `slither` 0.11.3 + `aderyn` 0.1.9 (the two available static tools).
+**Scoring** (`evaluate_extended_exploits.py`): per contract, run MIESC, map each
+finding to a vuln class (`classify_finding`), and score a **HIT** iff the
+contract's single auto-classified label class appears in the detected set;
+otherwise **MISS/FN**. A detected class that is neither the label nor `other`
+counts as a **FP**.
+
+> Note: `--sample 120` requested, but the stratified sampler caps at
+> `max(3, 120//8)=15` per class, and two classes are tiny (`front_running`=4,
+> `arithmetic`=2), so the **effective sample is 96 contracts**, not 120.
+
+### 2.1 Headline
+
+| Metric | Value |
+|--------|------:|
+| Contracts evaluated | 96 |
+| True positives (label class detected) | **0** |
+| False negatives | 96 |
+| False positives | 3 |
+| **Recall** | **0.00%** (0 / 96) |
+| **Precision** | **0.00%** |
+| Wall-clock | 168 s (~1.75 s/contract) |
+| Timeouts | 0 |
+
+Wilson 95% CI on recall = 0/96 → **[0.00%, 3.85%]**.
+
+Per-class: **every** class scored TP=0 / recall 0% (`flash_loan` 0/15,
+`oracle_manipulation` 0/15, `reentrancy` 0/15, `time_manipulation` 0/15,
+`delegation` 0/15, `access_control` 0/15, `front_running` 0/4, `arithmetic`
+0/2). Raw JSON: `benchmarks/results/extended_exploit_eval_20260811_120407.json`.
+
+### 2.2 Why it is 0% — and it is NOT "MIESC missed the bugs"
+
+The 0% is almost entirely a **compilation** outcome, not a detection outcome. The
+orchestrator copies each PoC into an isolated temp dir and invokes Slither/Aderyn
+on it alone. Every PoC then fails to compile because its imports are unreachable:
+
+```
+Error: Source "forge-std/Test.sol" not found ...
+Error: Source "./../interface.sol" not found ...
+Error: Source "../basetest.sol" not found ...
+```
+
+Slither/Aderyn return **0 findings** for a compile failure — which the harness,
+correctly, cannot distinguish from "analyzed and found nothing," so it scores FN.
+The 3 FPs come from a handful of PoCs with a small inline contract that partially
+compiled and produced an `unchecked_calls`/`time_manipulation` finding **on the
+attacker's own helper code** — i.e. the wrong class, hence FP not TP.
+
+**Bottom line for §2:** the number MIESC produces on the raw arena harness is
+**0/96 recall**, and it measures *"these fork-tests do not compile standalone,"*
+**not** MIESC's ability to detect the underlying vulnerabilities.
+
+---
+
+## 3. Fair ceiling — compile the PoCs in-context, then analyze
+
+To separate "compilation blocker" from "detection ability," I re-ran a stratified
+sample **inside the Foundry project** (`_defihacklabs/`), where `forge-std` (a
+vendored submodule) and `interface.sol` resolve, with explicit Slither remappings:
+
+```
+slither src/test/<date>/<name>_exp.sol \
+  --solc-remaps "forge-std/=lib/forge-std/src/ ds-test/=lib/forge-std/lib/ds-test/src/"
+```
+
+Now the PoCs compile. On `0vix_exp.sol`, Slither analyzes **161 contracts with
+100 detectors and returns 865 results** — but the results are on the **attacker's
+test harness** (`ContractTest`, `Exploiter`, forge-std, and the interface stubs):
+"state variable could be constant," "reentrancy in the exploit's own swap
+callback," etc. **None of it is the 0vix protocol's price-manipulation flaw**,
+because that contract's source is simply not present.
+
+**In-context experiment** (scratchpad `arena_incontext.py`, stratified 12
+contracts across 8 classes, per-file `--solc-remaps`, 90 s/file timeout, 314 s
+total). **All 12 compiled cleanly** (0 compile failures — the §2 blocker is gone):
+
+| Label class | Contracts | Label-class reached | Detectors/file (range) |
+|-------------|----------:|--------------------:|-----------------------:|
+| reentrancy | 1 | **1 (spurious — see below)** | 723 |
+| oracle_manipulation | 3 | 0 | 525–740 |
+| access_control | 2 | 0 | 713–766 |
+| arithmetic | 2 | 0 | 533–713 |
+| time_manipulation | 2 | 0 | 715–754 |
+| delegation | 1 | 0 | 712 |
+| flash_loan | 1 | 0 | 732 |
+| **Total** | **12** | **1 / 12 = 8.3%** | 525–766 |
+
+**The single "HIT" is a false positive of the metric, not a real detection.**
+Every one of the 12 files produced **525–766 Slither detectors**, and in **every**
+case the detected class set was the identical boilerplate triple **{other,
+reentrancy, unchecked_calls}** — the generic issues Slither always finds in
+`forge-std` + the interface stubs + the attacker's own callback. The lone HIT
+(`MEV_0x8c2d_exp.sol`, labeled `reentrancy`) "matched" only because *reentrancy is
+one of the three ever-present boilerplate detections*, not because Slither found
+the victim's reentrancy bug. The other 11 labels (oracle/access/arithmetic/
+time/delegation/flash_loan) are **never** reached, because none of them appear in
+the attacker-side boilerplate. So the honest in-context ceiling is **~0 genuine
+recall; 8.3% is an artifact of one label coinciding with boilerplate noise**.
+
+
+**Reading §3:** even when compilation is *not* the blocker, static analysis of a
+DeFiHackLabs PoC cannot recover the labeled victim vulnerability — the analyzer is
+looking at the exploit code, and the label describes a contract that isn't there.
+This is a **category mismatch between the corpus and static single-file analysis**,
+not a tunable MIESC parameter.
+
+---
+
+## 4. Honest interpretation
+
+- **The academic 83% recall (SmartBugs-Curated) does NOT transfer to this
+  corpus, and the gap is not "real-world contracts are harder."** It is that
+  SmartBugs contracts *are the vulnerable contracts* (self-contained, with
+  line-level labels), while DeFiHackLabs PoCs are *attack scripts against absent
+  on-chain victims*. Static single-file analysis is the right tool for the former
+  and the wrong tool for the latter.
+- **What a fair real-world arena would require** (future work, none faked here):
+  1. Resolve each exploit's **victim address** and **fetch verified victim source
+     from Etherscan** (the V2 key at `.env` works), then run MIESC on the *victim*.
+     Blocker today: the repo's `exploits_ground_truth.json` has
+     `contract_file=None` and **no addresses**; the auto-classified labels point at
+     the PoC, not the victim. Address extraction from PoC text is a separate
+     scraping project.
+  2. Or run MIESC's **on-chain / cross-contract** path (fork + trace), which the
+     static SmartBugs harness does not exercise.
+- **The 7/7 historical-exploit result** cited elsewhere (Parity $280M, The DAO
+  $60M, …) used **self-contained victim source** committed to the corpus — the same
+  reason it works and this arena does not.
+
+---
+
+## 5. Timing / performance
+
+- Raw arena (§2): 96 contracts in **168 s** (~1.75 s each) — fast precisely
+  because compilation fails early.
+- In-context (§3): 12 contracts in **314 s** (~26 s each) — far slower per
+  contract because each PoC drags in ~150–160 interface contracts + forge-std, so
+  each Slither invocation compiles a large unit (525–766 detectors emitted/file).
+
+---
+
+## 6. Freeze verification (zero frozen files touched)
+
+- `git status --porcelain` shows **zero tracked-file modifications**.
+- All new artifacts are **gitignored** (verified via `git check-ignore`):
+  - `data/datasets/rekt_exploits/contracts/*.sol` (fetched PoCs)
+  - `data/datasets/rekt_exploits/_defihacklabs/` (the clone)
+  - `benchmarks/results/extended_exploit_eval_20260811_120407.json` (raw arena)
+  - `benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md` (this file)
+- No `paper1_*`, `paper2_*`, `evmbench/*`, `fix_eval_results.json`,
+  `tooling_smoke_layers_1_6.json`, `docs/tesis/**`, or `paper/**` artifact was
+  read-modified. The in-context experiment ran a **scratchpad** script
+  (`/private/tmp/.../scratchpad/arena_incontext.py`), not a tracked repo file.
+
+---
+
+## 7. Limitations (read before citing any number here)
+
+1. **The 0% recall in §2 is a corpus/tooling mismatch, not a detection verdict.**
+   Do not cite "MIESC 0% on real-world exploits" without the §1.1/§2.2/§3
+   explanation — it would be as misleading as the withdrawn κ.
+2. **Labels are regex keyword-counts** on attack PoCs (`methodology` field),
+   *moderate* confidence, "manual review recommended for publication." They are not
+   verified victim vulnerabilities.
+3. **Victim source is absent** from the corpus; a valid arena needs Etherscan
+   victim-fetch or an on-chain trace path — future work, deliberately not faked.
+4. **Static-only, single machine, single run.** No LLM/ensemble/formal layers.
+5. **72 of 397 labels don't resolve** on this clone (dataset drift since the
+   Jul-12 frozen labels); those count as automatic FN in the raw harness.
+
+---
+
+*Additive real-world arena for MIESC v6.0.0. Reproduce §2 with:*
+`python3 benchmarks/build_datasets.py --rekt && python3 benchmarks/evaluate_extended_exploits.py --sample 120 --save`
+*(with a working `slither` on PATH via `export PATH=/opt/homebrew/bin:$PATH`).*

--- a/benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
+++ b/benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
@@ -204,10 +204,12 @@ not a tunable MIESC parameter.
 
 ## 6. Freeze verification (zero frozen files touched)
 
-- `git status --porcelain` shows **zero tracked-file modifications**.
-- All new artifacts are **gitignored** (verified via `git check-ignore`):
+- `git status --porcelain` showed **zero tracked-file modifications** before
+  versioning this additive report and its raw result JSON.
+- Dataset/cache artifacts remain **gitignored**:
   - `data/datasets/rekt_exploits/contracts/*.sol` (fetched PoCs)
   - `data/datasets/rekt_exploits/_defihacklabs/` (the clone)
+- Additive benchmark evidence is versioned on the benchmark branch:
   - `benchmarks/results/extended_exploit_eval_20260811_120407.json` (raw arena)
   - `benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md` (this file)
 - No `paper1_*`, `paper2_*`, `evmbench/*`, `fix_eval_results.json`,

--- a/benchmarks/results/v6.0.0_benchmark_report_20260811.md
+++ b/benchmarks/results/v6.0.0_benchmark_report_20260811.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-08-11
 **Run type**: Additive benchmark (no frozen paper artifact was modified — see §6).
-**Worktree**: `/Users/fboiero/Documents/GitHub/MIESC-main` (branch `main`, commit `be59229b`)
+**Worktree**: `/Users/fboiero/Documents/GitHub/MIESC-main` (branch `bench/v6.0.0-smartbugs`, base commit `be59229b`; benchmark report branch commit `0860b021`)
 **Machine**: macOS (darwin 25.4.0), single machine, Python 3.14.5.
 
 This is a benchmark **of the v6.0.0 solution** on real data. It reports the
@@ -390,11 +390,12 @@ dent in **reentrancy** (180 of 909 removed). Four categories see **zero** remova
 
 ### 8.5 Freeze note for this addition
 
-- New additive artifacts only (both gitignored, collide with no frozen file):
+- New additive artifacts only (collide with no frozen file):
   - `benchmarks/results/smartbugs_fp_filter_effect_20260811.json`
-  - `benchmarks/smartbugs_fp_filter_effect_20260811.py` (new untracked helper, adapted
+  - `benchmarks/smartbugs_fp_filter_effect_20260811.py` (new helper, adapted
     from the pre-existing `smartbugs_fp_filter_effect_20260710.py`; import fixed
     `src.ml` → `miesc.ml` after the package unification)
 - This section was **appended** to the report; no existing content above was altered.
-- `git status --porcelain` shows **no tracked-file modifications** — only new untracked
-  files. No frozen paper artifact was touched.
+- The script, its dated JSON output, and this report are versioned as additive
+  benchmark evidence on `bench/v6.0.0-smartbugs`. No frozen paper artifact was
+  touched.

--- a/benchmarks/results/v6.0.0_benchmark_report_20260811.md
+++ b/benchmarks/results/v6.0.0_benchmark_report_20260811.md
@@ -1,0 +1,400 @@
+# MIESC v6.0.0 Benchmark Report
+
+**Date**: 2026-08-11
+**Run type**: Additive benchmark (no frozen paper artifact was modified — see §6).
+**Worktree**: `/Users/fboiero/Documents/GitHub/MIESC-main` (branch `main`, commit `be59229b`)
+**Machine**: macOS (darwin 25.4.0), single machine, Python 3.14.5.
+
+This is a benchmark **of the v6.0.0 solution** on real data. It reports the
+**real measured numbers** for the toolset that was actually available on this
+machine. Where those numbers are lower than a documented profile, that is stated
+plainly (§3.2). No number here is rounded optimistically or cherry-picked.
+
+---
+
+## 1. Environment & toolset
+
+| Component | Version / status |
+|-----------|------------------|
+| MIESC | 6.0.0 (checkout at `be59229b`) |
+| Slither | 0.11.3 (invoked via `/opt/homebrew/bin/slither`) |
+| Aderyn | 0.1.9 |
+| Solhint | 6.0.1 (not exercised by this harness) |
+| solc | via solc-select artifacts (0.4.22–0.8.20 present) |
+| Foundry / forge | 1.3.5-stable |
+| Mythril | **ABSENT** (optional — not installed; noted honestly) |
+| Dataset | SmartBugs-Curated, 143 contracts, 207 tagged vulnerabilities (10 DASP categories) |
+| Ground truth | Upstream `vulnerabilities.json` (SmartBugs-Curated `main`), fetched to the gitignored dataset path the harness expects |
+
+### 1.1 Environment note (reproducibility-critical)
+
+On this machine the PATH-resolved `slither`, `solc`, and `solc-select`
+executables (`/usr/local/bin/*`) have a **broken shebang** — they point at
+`/Library/Developer/CommandLineTools/usr/bin/python3`, which no longer exists.
+They fail with `bad interpreter`. A working Slither 0.11.3 exists at
+`/opt/homebrew/bin/slither` (Python 3.14 Homebrew). To run the harness unchanged,
+a small shim directory was prepended to PATH exposing working `slither` and
+`solc-select` wrappers. **No repository file was modified** to achieve this.
+
+The harness also expects `benchmarks/datasets/smartbugs-curated/vulnerabilities.json`,
+which was absent (it is **gitignored** — line 114/288 of `.gitignore` — and fetched
+on demand by `benchmarks/build_datasets.py --smartbugs`). It was fetched verbatim
+from the upstream SmartBugs-Curated repository. All 143 local contract paths match
+the ground-truth entries exactly; 0 missing.
+
+### 1.2 Which layers actually ran
+
+This run exercised the **static / heuristic path only**:
+
+- **Slither 0.11.3** (Layer 1, static analysis) — the workhorse; ran on all 143.
+- **MIESC SmartBugs detectors** (`miesc.detectors.smartbugs_detectors`) — Python
+  heuristic detectors targeting the DASP categories.
+- **Aderyn 0.1.9** — best-effort. Aderyn needs a compatible `solc` on PATH to
+  compile; the PATH `solc` is broken and most SmartBugs contracts are old
+  (0.4.x/0.5.x) which Aderyn 0.1.9 cannot compile. Aderyn therefore contributed
+  **effectively zero** findings on this corpus. The harness handles this
+  gracefully (it only records a contract-level error when *both* Slither and
+  Aderyn fail; Slither succeeded everywhere, so `errors_count = 0`).
+
+**No LLM layers, no formal verification, no agentic loop ran.** This matters for
+the comparison in §3.2 — the frozen paper baselines include LLM/specialized
+layers this run did not.
+
+---
+
+## 2. SmartBugs-Curated results (headline)
+
+**Scoring method (exact).** Per contract, the harness maps each ground-truth
+vulnerability and each detected finding to a DASP category and to a set of source
+lines (`benchmarks/smartbugs_evaluation.py::match_findings`). For a category:
+`TP = |gt_lines ∩ detected_lines|`; if no line overlaps but the category is both
+present in ground truth and detected, a single partial TP is credited;
+`FP = |detected_lines − gt_lines|`; `FN = |gt_lines − detected_lines|`. This is a
+**line-granular** scorer, so a detector that flags many lines in a contract earns
+many FPs. Overall precision/recall/F1 are computed from the summed TP/FP/FN.
+
+**Run**: `python3 benchmarks/smartbugs_evaluation.py` (all 143 contracts,
+4-worker parallel, 120 s/contract timeout).
+**Raw output**: `benchmarks/results/smartbugs_evaluation_20260811_110804.json`
+(+ per-contract `smartbugs_detailed_20260811_110804.json`).
+
+### 2.1 Overall
+
+| Metric | Value |
+|--------|------:|
+| Contracts analyzed | 143 |
+| Ground-truth vulnerabilities | 207 |
+| Findings emitted | 1663 |
+| True positives | 193 |
+| False positives | 1263 |
+| False negatives | 39 |
+| **Precision** | **13.26%** |
+| **Recall** | **83.19%** |
+| **F1** | **22.87%** |
+| Wall-clock | 31.3 s total |
+| Avg / contract | 0.22 s |
+| Contract errors | 0 |
+
+### 2.2 Per category
+
+| Category | Contracts | TP | FP | FN | Precision | Recall | F1 |
+|----------|----------:|---:|---:|---:|----------:|-------:|---:|
+| access_control | 18 | 18 | 27 | 12 | 40.00% | 60.00% | 48.00% |
+| arithmetic | 15 | 20 | 18 | 4 | 52.63% | 83.33% | 64.52% |
+| bad_randomness | 8 | 29 | 29 | 5 | 50.00% | 85.29% | 63.04% |
+| denial_of_service | 6 | 6 | 6 | 10 | 50.00% | 37.50% | 42.86% |
+| front_running | 4 | 6 | 2 | 1 | 75.00% | 85.71% | 80.00% |
+| other | 3 | 0 | 0 | 5 | 0.00% | 0.00% | 0.00% |
+| reentrancy | 31 | 32 | 909 | 0 | 3.40% | 100.00% | 6.58% |
+| short_addresses | 1 | 1 | 0 | 0 | 100.00% | 100.00% | 100.00% |
+| time_manipulation | 5 | 6 | 12 | 2 | 33.33% | 75.00% | 46.15% |
+| unchecked_low_level_calls | 52 | 75 | 260 | 0 | 22.39% | 100.00% | 36.59% |
+
+**Honest reading of the numbers.**
+
+- **Recall (83.19%)** is carried by the high-volume categories — `reentrancy`,
+  `unchecked_low_level_calls` (both 100%), `arithmetic`, `bad_randomness`,
+  `front_running`. Slither + the SmartBugs detectors find these reliably.
+- **Precision (13.26%) is genuinely low**, and it is dominated by **one category:
+  `reentrancy` contributes 909 of the 1263 FPs**. Under this line-granular scorer,
+  Slither's reentrancy detectors + the heuristic detectors flag many lines per
+  contract; every flagged line that is not the single tagged line counts as a FP.
+  This is a property of *this scorer at this operating point*, not evidence the
+  tool is "wrong" — but the number is what it is and is reported unmodified.
+- **Real recall gaps**: `denial_of_service` (37.5%) and `other` (0%) — categories
+  that need semantic/LLM reasoning the static path does not provide.
+- Minor harness accounting quirk: per-category FN sums to 38 while the overall FN
+  is 39 (one finding lands outside the 10 named categories in the aggregate path).
+  The overall figures above are reported verbatim from the JSON; recall is
+  `193 / (193 + 39) = 83.19%`.
+
+---
+
+## 3. Comparison to documented baselines (like-for-like caveats)
+
+### 3.1 The frozen paper baselines (DO NOT conflate with this run)
+
+| Profile (frozen) | Layers | P | R | F1 | Time |
+|------------------|--------|--:|--:|---:|-----:|
+| `paper1_smartbugs_eval.json` (MIESC 5.4.0) | 1,5,7,9 | 22.26% | 89.51% | 35.65% | 631 s |
+| `paper1_smartbugs_eval_layers_1_6_7.json` | 1,6,7 | 22.19% | 95.80% | 36.04% | 737 s |
+| **This run (v6.0.0)** | **1 + SmartBugs detectors (static only)** | **13.26%** | **83.19%** | **22.87%** | **31.3 s** |
+
+### 3.2 Interpretation — this run is NOT the paper number, and here is why
+
+**This run's precision and recall are both LOWER than the frozen paper
+profiles, and I am not claiming the paper's numbers.** The reasons are concrete
+and toolset-driven:
+
+1. **Different, smaller toolset.** The frozen profiles include LLM analysis
+   (layer 5/6), specialized analysis (layer 7), and an AI ensemble (layer 9).
+   This run had **no LLM/specialized/ensemble layers** — only static Slither plus
+   the Python SmartBugs heuristics. Fewer layers → lower recall on the
+   reasoning-heavy categories (`denial_of_service`, `other`).
+2. **Lower precision at this operating point.** The frozen 1/6/7 profile scored
+   109 reentrancy FPs; this static-only run scored 909, because the heuristic
+   detectors emit more line-level findings without the downstream LLM/ensemble
+   filtering the paper profiles apply. The FP filter / triage / confidence layers
+   (validated in §4) are *available* but were **not** wired into this raw
+   detection harness — the harness reports unfiltered detector output by design.
+3. **The ~80%R / 22.7%P figure in project memory** corresponds to the layers
+   1,5,7,9 paper profile (89.5%R / 22.3%P), **not** a static-only run. Comparing
+   this run to it is apples-to-oranges; the honest statement is: *with a
+   static-only toolset and no post-filtering, v6.0.0 reproduces ~83% recall but at
+   ~13% precision on the punishing line-granular scorer.*
+
+The take-away is not "v6 regressed." It is: **the raw static path alone is a
+high-recall / low-precision layer**, exactly as the layered architecture assumes.
+The precision recovery is the job of the confidence / triage / FP-filter layers —
+which this report validates separately in §4, but which the raw-detection harness
+deliberately does not apply.
+
+---
+
+## 4. v6 feature validation (additive, on REAL SmartBugs findings)
+
+Validated against real findings extracted from a 4-contract sample
+(`reentrancy/0x23a9…`, `arithmetic/BECToken.sol`, `access_control/FibonacciBalance.sol`,
+`bad_randomness/random_number_generator.sol` — 48 real findings total).
+Raw output: scratchpad `v6_out.json` (reproduced inline below).
+
+### 4.1 ⚠️ Acceptance-pattern provider — NOT present on this checkout (honest)
+
+The task asked to validate `from miesc.core.acceptance_providers import
+auto_acceptance_provider` and `miesc/ml/triage_ranker.py::apply_acceptance_ordering`.
+**Neither symbol exists on this `main` worktree, nor in the sibling
+`/Users/fboiero/Documents/GitHub/MIESC` checkout.** `miesc.core.acceptance_providers`
+raises `ModuleNotFoundError`; `apply_acceptance_ordering` is not defined in
+`triage_ranker.py`. That feature lives on an **unmerged lane** and could not be
+benchmarked here. Reported as unavailable rather than faked.
+
+**What DOES exist and was validated** is the genuine recall-safe reordering
+primitive it would build on: `miesc.ml.triage_ranker.rank_results`, documented as
+*"Reorder each result's findings by P(real), in place — recall-safe (never
+drops)."* A trained triage model is present (`TriageRanker().available() == True`).
+
+**Recall-safe reordering proof:**
+
+| Check | Value |
+|-------|------:|
+| Findings in | 48 |
+| Findings out | 48 |
+| Recall-safe (count-in == count-out, none dropped) | **YES** |
+| Contracts whose top-ordering changed | 3 |
+
+Before/after top-3 (e.g. `BECToken.sol`): `[Integer Overflow, Integer Overflow,
+Front-Running]` → `[Front-Running, Front-Running, Front-Running]` — order changed,
+**count preserved, zero findings dropped**. This is the recall-safe reorder
+guarantee, demonstrated on real data.
+
+### 4.2 Confidence calibration + `--min-confidence` gating
+
+`miesc.core.confidence.annotate_confidence` annotated all 48 findings
+(calibrated score ∈ [0,1] + `confidence_level`).
+
+- Score range on the sample: **min 0.50, max 0.85**.
+- Distribution: `0.5–0.75`: 33 findings; `0.75–1.0`: 15 findings; below 0.5: 0.
+
+`filter_by_min_confidence` gating counts:
+
+| `--min-confidence` | Kept | Dropped |
+|-------------------:|-----:|--------:|
+| 0.0 | 48 | 0 |
+| 0.3 | 48 | 0 |
+| 0.5 | 48 | 0 |
+| 0.7 | 15 | 33 |
+| 0.9 | 0 | 48 |
+
+**Honest note:** gating **filters what is reported** (trades volume/precision at a
+threshold); it is **NOT** claimed to improve recall — a higher threshold can only
+drop findings, never add them. Findings without a `confidence` key default to 1.0
+so they are never silently dropped.
+
+### 4.3 Finding baseline (T1.1) — generate + diff
+
+`miesc.core.baseline` on `reentrancy/0x23a9…` (4 findings):
+
+| Step | Result |
+|------|-------:|
+| Findings baselined | 4 |
+| Baseline entries (after dedup) | 4 |
+| Re-run diff → **new** | **0** |
+| Re-run diff → known | 4 |
+| Re-run diff → fixed | 0 |
+| After injecting 1 synthetic-new finding → new | **1** |
+
+Baselining suppresses all known findings (0 new on re-run) **and** still surfaces
+a genuinely new finding when one is introduced. The T1.1 baseline contract holds.
+
+---
+
+## 5. Timing / performance
+
+- **Total wall-clock**: 31.3 s for all 143 contracts (4-worker parallel).
+- **Avg per contract**: 0.22 s.
+- This is far faster than the frozen paper profiles (631 s / 737 s) precisely
+  because **no LLM layer ran** — the LLM layers dominate the paper wall-clock.
+- Tool availability: Slither ✅, Aderyn ⚠️ (present but no-op on this old corpus
+  due to broken PATH `solc`), Solhint ✅ (unused by this harness), Mythril ❌
+  (absent — optional).
+
+---
+
+## 6. Freeze verification (zero frozen files touched)
+
+- `benchmarks/results/*` is **gitignored** (`.gitignore:114`); the paper freeze is
+  enforced by a checksum manifest (`.paper-freeze-local/`, local to the primary
+  clone, not present in this worktree), not by git tracking.
+- New files produced by this run use fresh timestamped names that **collide with
+  no frozen artifact**:
+  - `benchmarks/results/smartbugs_evaluation_20260811_110804.json`
+  - `benchmarks/results/smartbugs_detailed_20260811_110804.json`
+  - `benchmarks/results/v6.0.0_benchmark_report_20260811.md` (this file)
+- All 18 frozen artifacts (`paper1_*`, `paper2_*`, `evmbench/*.json`,
+  `fix_eval_results.json`, `tooling_smoke_layers_1_6.json`) retain their original
+  `Jul 12 17:42` mtime — **untouched**.
+- `git status --porcelain` shows **no modified files** (`M`); the only new files
+  are the additive results above (themselves gitignored, so invisible to git —
+  they cannot affect any tracked/frozen artifact).
+- The fetched `vulnerabilities.json` is the gitignored ground-truth path; it does
+  not appear in `git status` and is not a frozen artifact.
+
+---
+
+## 7. Limitations (read before citing any number here)
+
+1. **Static-only run.** No LLM, no specialized, no ensemble, no formal
+   verification, no agentic loop. Recall on reasoning-heavy categories
+   (`denial_of_service`, `other`) is correspondingly weak.
+2. **Precision is unfiltered.** The raw-detection harness does not apply the
+   confidence/triage/FP-filter layers (validated in §4). The reported 13.26%
+   precision is the *pre-filter* operating point of the static path, not the
+   end-to-end product precision.
+3. **Aderyn contributed ~nothing** on this corpus (old Solidity + broken PATH
+   `solc`); results are effectively "Slither + SmartBugs heuristics."
+4. **Line-granular scorer** is punishing on high-volume detectors (see the 909
+   reentrancy FPs). A contract-level or overlap-tolerant scorer would report
+   higher precision; the harness's method is used as-is for comparability.
+5. **Single machine, single run.** No confidence intervals; timing is indicative.
+6. **Acceptance-pattern provider not benchmarked** — absent from this checkout
+   (§4.1). The recall-safe reordering primitive it builds on *was* validated.
+7. **Mythril absent** (optional tool).
+
+---
+
+*Generated as an additive v6.0.0 evaluation. Reproduce with:*
+`python3 benchmarks/smartbugs_evaluation.py` *(with a working `slither` on PATH and*
+`benchmarks/datasets/smartbugs-curated/vulnerabilities.json` *fetched via*
+`python3 benchmarks/build_datasets.py --smartbugs`*).*
+
+---
+
+## 8. Solution Pipeline (with FP-filter / confidence) — added 2026-08-11
+
+§2 measured the **raw static detection layer** — no post-filtering, by design. But
+the shipped `miesc scan` applies the production `FalsePositiveFilter` on top of the
+raw detectors. This section measures **what the product actually returns**, so the
+comparison is apples-to-apples with the 13.26% / 83.19% raw baseline.
+
+**Method (identical scorer, one added step).** Same 143 contracts, same upstream
+ground truth, same detectors (Slither + Aderyn + SmartBugs), same
+`smartbugs_evaluation.py::match_findings` line-granular scorer. The **only** added
+step is the production filter, constructed exactly as `miesc scan` does —
+`FalsePositiveFilter(strictness="medium", use_rag=False)` — dropping every finding
+where `filter_finding(...).is_likely_fp` is true (the identical `not fr.is_likely_fp`
+keep-rule the CLI uses). RAG was left off to match the default offline path and to
+avoid confounding the measurement with an embedding model.
+
+**Run**: `python3 benchmarks/smartbugs_fp_filter_effect_20260811.py` (sequential, 143
+contracts, 286.3 s wall-clock).
+**Raw output**: `benchmarks/results/smartbugs_fp_filter_effect_20260811.json`.
+The script's internally-recomputed raw baseline reproduced §2 **exactly**
+(TP 193 / FP 1263 / FN 39), confirming the two runs are directly comparable.
+
+### 8.1 Headline: raw static layer vs shipped solution
+
+| Pipeline | TP | FP | FN | Precision | Recall | F1 |
+|----------|---:|---:|---:|----------:|-------:|---:|
+| Raw static layer (§2, no filter) | 193 | 1263 | 39 | **13.26%** | **83.19%** | **22.87%** |
+| **Solution (FP-filter, strictness=medium)** | 193 | 1056 | 39 | **15.45%** | **83.19%** | **26.06%** |
+| **Delta** | 0 | **−207** | 0 | **+2.19 pp** | **±0.00** | **+3.19 pp** |
+
+### 8.2 Recall-safety check (the number that matters most)
+
+- **True positives: 193 → 193. Zero TP lost.** Recall is **unchanged at 83.19%**.
+- FPs removed: **207** (1263 → 1056).
+- The filter is **verified recall-safe on this corpus**: it removed 207 false
+  positives and dropped **not a single one** of the 193 true positives. This matches
+  the documented recall-safe design claim — measured, not assumed.
+
+### 8.3 Where the filter acts (and where it doesn't)
+
+Only **15 of 143** contracts had any FP removed. Per category (raw FP → filtered FP):
+
+| Category | FP raw → filtered | Removed | TP (unchanged) | Precision raw → filtered |
+|----------|------------------:|--------:|---------------:|-------------------------:|
+| arithmetic | 18 → 7 | 11 | 20 | 52.6% → **74.1%** |
+| bad_randomness | 29 → 16 | 13 | 29 | 50.0% → **64.4%** |
+| reentrancy | 909 → 729 | 180 | 32 | 3.4% → 4.2% |
+| unchecked_low_level_calls | 260 → 257 | 3 | 75 | 22.4% → 22.6% |
+| access_control | 27 → 27 | 0 | 18 | 40.0% → 40.0% |
+| denial_of_service | 6 → 6 | 0 | 6 | 50.0% → 50.0% |
+| front_running | 2 → 2 | 0 | 6 | 75.0% → 75.0% |
+| time_manipulation | 12 → 12 | 0 | 6 | 33.3% → 33.3% |
+| short_addresses / other | 0 → 0 | 0 | 1 / 0 | — |
+
+The filter's suppressions fire almost entirely on **arithmetic** (SafeMath / version
+-aware overflow suppression) and **bad_randomness** class patterns, plus a partial
+dent in **reentrancy** (180 of 909 removed). Four categories see **zero** removals.
+
+### 8.4 Honest verdict — the filter is recall-safe but "weak alone"
+
+- **Recall-safe: confirmed.** 0 true positives dropped; recall held at 83.19%. This
+  is the strong, load-bearing result — the filter never costs recall on this corpus.
+- **Precision help: real but modest — "weak alone" is the honest label.** Precision
+  moves only **+2.19 points (13.26% → 15.45%)** and F1 **+3.19 points**. Why so
+  small? Because **1056 FPs remain**, and **729 of them are still in `reentrancy`** —
+  the category that dominates the FP mass under this line-granular scorer. The filter
+  trims 180 reentrancy FPs but does not touch the structural cause (Slither's
+  reentrancy detectors flagging many non-tagged lines per contract). Where the filter
+  *does* have leverage — arithmetic (52.6% → 74.1%) and bad_randomness (50% → 64.4%) —
+  the per-category precision jumps are large; those categories are just too small to
+  move the aggregate much.
+- **Conclusion.** As the architecture documents, the FP-filter is a **recall-safe
+  precision layer, not a precision fix on its own**. The end-to-end precision recovery
+  the layered design targets requires the confidence / triage / LLM-ensemble layers
+  (validated separately in §4) that this static-only harness does not wire in. The
+  shipped solution's static+filter operating point on SmartBugs-curated is
+  **P 15.45% / R 83.19% / F1 26.06%** — a genuine but modest improvement over the raw
+  13.26% / 83.19% / 22.87%, achieved with **zero recall cost**.
+
+### 8.5 Freeze note for this addition
+
+- New additive artifacts only (both gitignored, collide with no frozen file):
+  - `benchmarks/results/smartbugs_fp_filter_effect_20260811.json`
+  - `benchmarks/smartbugs_fp_filter_effect_20260811.py` (new untracked helper, adapted
+    from the pre-existing `smartbugs_fp_filter_effect_20260710.py`; import fixed
+    `src.ml` → `miesc.ml` after the package unification)
+- This section was **appended** to the report; no existing content above was altered.
+- `git status --porcelain` shows **no tracked-file modifications** — only new untracked
+  files. No frozen paper artifact was touched.

--- a/benchmarks/smartbugs_fp_filter_effect_20260811.py
+++ b/benchmarks/smartbugs_fp_filter_effect_20260811.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Additive experiment (2026-08-11): measure the SHIPPED SOLUTION's precision/recall
+on SmartBugs-curated through the production false-positive filter path, versus the
+raw unfiltered detector baseline that benchmarks/smartbugs_evaluation.py reports
+(P 13.26 / R 83.19 / F1 22.87; TP 193 / FP 1263 / FN 39, run 20260811_110804).
+
+Rationale: `miesc scan` applies miesc/ml/fp_filter.py FalsePositiveFilter by default
+(strictness=medium), but the raw benchmark calls the detectors directly and never
+runs that filter. This script isolates the filter's effect: SAME detectors
+(Slither + Aderyn + SmartBugs), SAME ground truth, SAME match_findings scoring as
+smartbugs_evaluation.py -- the only added step is the production filter, kept/dropped
+by the identical `not fr.is_likely_fp` rule scan.py uses.
+
+Writes a NEW dated result file. Does NOT touch any frozen paper artifact.
+Adapted from smartbugs_fp_filter_effect_20260710.py (import fixed src.ml -> miesc.ml
+after the src/->miesc/ package unification).
+"""
+import json
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "benchmarks"))
+
+import smartbugs_evaluation as sbe  # noqa: E402
+from miesc.ml.fp_filter import FalsePositiveFilter  # noqa: E402
+
+
+_CONFIDENCE_LEVELS = {"high": 0.9, "medium": 0.7, "low": 0.4, "informational": 0.2}
+
+
+def _confidence_to_float(value) -> float:
+    """The filter expects numeric confidence (as production findings carry); the
+    benchmark findings carry string levels ('High'/'Medium'/'Low'). Normalize."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return _CONFIDENCE_LEVELS.get(value.strip().lower(), 0.7)
+    return 0.7
+
+
+def metrics(tp: int, fp: int, fn: int) -> dict:
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": round(p, 4),
+        "recall": round(r, 4),
+        "f1": round(f1, 4),
+    }
+
+
+def main() -> None:
+    truth = sbe.load_ground_truth()
+    # Mirror `miesc scan` default construction exactly.
+    fpf = FalsePositiveFilter(strictness="medium", use_rag=False)
+
+    raw = defaultdict(lambda: [0, 0, 0])  # category -> [tp, fp, fn]
+    flt = defaultdict(lambda: [0, 0, 0])
+    per_contract = []
+    t0 = time.time()
+    items = sorted(truth.items())
+
+    for i, (rel_path, info) in enumerate(items, 1):
+        contract_path = sbe.DATASET_PATH / rel_path
+        category = rel_path.split("/")[1] if "/" in rel_path else "unknown"
+        if not contract_path.exists():
+            continue
+
+        slither = sbe.run_miesc_analysis(contract_path)
+        aderyn = sbe.run_aderyn_analysis(contract_path)
+        sb = sbe.run_smartbugs_detectors(contract_path, min_confidence=sbe._MIN_CONFIDENCE)
+        detected = sbe.extract_findings(slither, aderyn, sb)
+
+        try:
+            source = contract_path.read_text(errors="replace")
+        except Exception:
+            source = ""
+
+        # Apply the production filter. Populate the fields fp_filter reads
+        # (type/severity) from the benchmark's category/impact so the class-based
+        # suppression (e.g. SafeMath/0.8 arithmetic) can fire as it does in production.
+        kept = []
+        for f in detected:
+            ff = dict(f)
+            ff.setdefault("type", f.get("category", ""))
+            ff.setdefault("severity", f.get("impact", f.get("severity", "")))
+            ff["confidence"] = _confidence_to_float(f.get("confidence"))
+            fr = fpf.filter_finding(ff, code_context=source, file_path=str(contract_path))
+            if not fr.is_likely_fp:
+                kept.append(f)
+
+        gt = info["vulnerabilities"]
+        rtp, rfp, rfn = sbe.match_findings(gt, detected, category)
+        ktp, kfp, kfn = sbe.match_findings(gt, kept, category)
+        raw[category][0] += rtp
+        raw[category][1] += rfp
+        raw[category][2] += rfn
+        flt[category][0] += ktp
+        flt[category][1] += kfp
+        flt[category][2] += kfn
+        per_contract.append(
+            {
+                "path": rel_path,
+                "category": category,
+                "raw": [rtp, rfp, rfn],
+                "filtered": [ktp, kfp, kfn],
+                "fps_removed": rfp - kfp,
+                "tps_lost": rtp - ktp,
+                "detected": len(detected),
+                "kept": len(kept),
+            }
+        )
+        print(
+            f"  [{i}/{len(items)}] {rel_path:<55} fp {rfp}->{kfp}  tp {rtp}->{ktp}",
+            flush=True,
+        )
+
+    def agg(d):
+        tp = sum(v[0] for v in d.values())
+        fp = sum(v[1] for v in d.values())
+        fn = sum(v[2] for v in d.values())
+        return metrics(tp, fp, fn)
+
+    raw_agg = agg(raw)
+    flt_agg = agg(flt)
+    out = {
+        "experiment": "smartbugs_fp_filter_effect",
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "note": (
+            "ADDITIVE experiment, not part of frozen paper evidence. Same detectors "
+            "(Slither+Aderyn+SmartBugs), same ground truth, same match_findings scoring "
+            "as smartbugs_evaluation.py. Only added step: production FalsePositiveFilter "
+            "(strictness=medium, use_rag=False), dropping findings where fr.is_likely_fp, "
+            "exactly as `miesc scan` does. Measures what the shipped product actually returns."
+        ),
+        "raw_baseline": raw_agg,
+        "filtered_production": flt_agg,
+        "delta": {
+            "fps_removed": raw_agg["fp"] - flt_agg["fp"],
+            "tps_lost": raw_agg["tp"] - flt_agg["tp"],
+            "precision_gain": round(flt_agg["precision"] - raw_agg["precision"], 4),
+            "recall_change": round(flt_agg["recall"] - raw_agg["recall"], 4),
+        },
+        "per_category": {
+            c: {"raw": metrics(*raw[c]), "filtered": metrics(*flt[c])}
+            for c in sorted(set(raw) | set(flt))
+        },
+        "per_contract": per_contract,
+        "total_time_s": round(time.time() - t0, 1),
+        "contracts_evaluated": len(per_contract),
+    }
+    outpath = PROJECT_ROOT / "benchmarks" / "results" / "smartbugs_fp_filter_effect_20260811.json"
+    outpath.write_text(json.dumps(out, indent=2))
+
+    print("\n" + "=" * 64)
+    print(f"  RAW      : {raw_agg}")
+    print(f"  FILTERED : {flt_agg}")
+    print(
+        f"  FPs removed: {raw_agg['fp'] - flt_agg['fp']}  |  TPs lost: "
+        f"{raw_agg['tp'] - flt_agg['tp']}  |  recall {raw_agg['recall']} -> {flt_agg['recall']}"
+    )
+    print(f"  wrote {outpath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/SDD_LENDING_SOLVENCY_LIQUIDATION_HARDENING_20260811.md
+++ b/docs/SDD_LENDING_SOLVENCY_LIQUIDATION_HARDENING_20260811.md
@@ -1,0 +1,327 @@
+# SDD: Lending Solvency and Liquidation Hardening
+
+Date: 2026-08-11
+Owner/Lane: Codex
+Status: Proposed SDD, not implemented, no benchmark claim
+
+## Signal
+
+MIESC already has strong partial coverage for DeFi lending risk:
+
+- `economic_attack_simulation` models profit, capital, flash-loan, slippage,
+  oracle assumptions, and liquidation economics.
+- `oracle_feed_hardening` validates price feed freshness, completeness, bounds,
+  decimals, deviation controls, fallback trust, and L2 sequencer assumptions.
+- `financial_math_precision_hardening` covers rounding, scale, accumulator,
+  debt-index, interest, health-factor, and liquidation-threshold formulas.
+- `sequence_oracle_detection` can plan multi-transaction paths such as
+  manipulate price, borrow, accrue, repay, and liquidate.
+- `snapshot_fuzzing_guidance` can reuse collateralized, insolvent, or
+  near-liquidation states.
+- `semantic_graph_gating` and SlithIR SSA summaries can anchor state reads,
+  writes, oracle reads, debt flows, and liquidation calls.
+
+The missing surface is a unified provider-neutral artifact for **protocol
+solvency**. A lending protocol can pass individual oracle checks and still be
+unsafe if collateral valuation, debt accounting, liquidation eligibility,
+liquidation incentive, interest accrual, reserve accounting, close factors,
+pause modes, or bad-debt absorption do not compose correctly over time.
+
+The technique to add is **Lending Solvency and Liquidation Hardening**: synthesize
+solvency-state models and liquidation-oracle obligations that connect collateral,
+debt, price, interest, liquidation, reserve, and recovery paths. The output is an
+advisory validation plan until a replay, local fixture, symbolic counterexample,
+or fuzz campaign demonstrates insolvent borrowing, blocked liquidation,
+underwater withdrawal, bad-debt amplification, or protocol accounting drift.
+
+## Spec/Goal
+
+Add a future capability named:
+
+```text
+lending_solvency_liquidation_hardening
+```
+
+Expected output key:
+
+```text
+lending_solvency_liquidation_plans
+```
+
+Suggested aliases:
+
+```text
+solvency_liquidation_hardening
+lending_health_factor_hardening
+collateral_debt_invariant_plans
+liquidation_oracle_hardening
+bad_debt_recovery_hardening
+```
+
+The capability must produce advisory solvency/liquidation plans, not confirmed
+findings. A plan becomes a finding only after deterministic replay, fuzzing,
+symbolic execution, local fixture validation, fork validation, or human review
+confirms a reachable insolvency, liquidation bypass, bad-debt drift, or unfair
+liquidation path.
+
+Primary objectives:
+
+1. Identify lending markets, collateral assets, debt assets, reserves, indexes,
+   shares, exchange rates, collateral factors, liquidation thresholds, close
+   factors, bonuses, penalties, and bad-debt accounting fields.
+2. Identify solvency-critical functions: deposit/supply, withdraw/redeem,
+   borrow, repay, accrueInterest, liquidate, seize, absorb, rebalance, pause,
+   configureMarket, updateOracle, and emergency recovery.
+3. Infer protocol invariants: collateral value covers borrow value under stated
+   thresholds, debt indexes are monotonic, reserves remain solvent, withdrawals
+   cannot make an account undercollateralized, liquidation reduces risk, and bad
+   debt is accounted for once.
+4. Generate validation obligations for near-threshold states, stale or shifted
+   prices, interest accrual gaps, rounding boundaries, liquidation incentive
+   edges, close-factor splits, partial repay paths, oracle downtime, paused
+   markets, and post-liquidation accounting.
+5. Preserve false-positive controls for deliberately overcollateralized,
+   isolated, capped, paused, guardian-controlled, or oracle-protected markets.
+
+## Design/Contract
+
+Introduce a provider-neutral data contract before implementation:
+
+```python
+LendingSolvencyLiquidationPlan = {
+    "id": "string",
+    "objective": "string",
+    "market_model": {
+        "markets": [
+            {
+                "id": "string",
+                "collateral_asset": "string",
+                "debt_asset": "string",
+                "price_source": "string",
+                "collateral_factor": "string",
+                "liquidation_threshold": "string",
+                "close_factor": "string",
+                "liquidation_bonus": "string",
+                "interest_index": "string",
+                "reserve_account": "string",
+                "source_anchors": ["file:line"],
+            }
+        ],
+        "accounting_fields": ["collateral", "debt", "shares", "indexes", "reserves", "bad_debt"],
+        "price_dependencies": ["oracle_feed_id"],
+        "configuration_actors": ["admin", "governor", "guardian"],
+    },
+    "solvency_hypothesis": {
+        "category": "insolvent_borrow|unsafe_withdraw|liquidation_bypass|liquidation_over_seizure|liquidation_under_seizure|interest_accrual_gap|oracle_decimal_shift|stale_price_solvency|bad_debt_double_count|reserve_drift|paused_market_recovery_gap|rounding_threshold_flip",
+        "attacker_or_market_condition": "string",
+        "unsafe_state_transition": "string",
+        "affected_market": "string",
+        "preconditions": ["string"],
+        "negative_checks": ["string"],
+    },
+    "solvency_oracle": {
+        "property": "string",
+        "safe_state_condition": "string",
+        "forbidden_state_condition": "string",
+        "post_liquidation_condition": "string",
+        "bad_debt_accounting_condition": "string",
+    },
+    "execution_plan": {
+        "recommended_tools": ["foundry", "halmos", "echidna", "slither", "anvil", "local_fixture", "human_review"],
+        "sequence": ["call"],
+        "actors": ["borrower", "liquidator", "supplier", "admin", "keeper", "attacker"],
+        "inputs_to_mutate": ["prices", "collateral_amounts", "borrow_amounts", "repay_amounts", "time_delta", "rounding_edges"],
+        "snapshot_state_hint": "near threshold, underwater, stale oracle, or post-accrual",
+        "fork_or_timewarp_hint": "string",
+    },
+    "promotion": {
+        "state": "hypothesis|test_generated|counterexample|replayed|rejected",
+        "evidence": ["string"],
+        "blockers": ["string"],
+    },
+    "metadata": {
+        "capability": "lending_solvency_liquidation_hardening",
+        "schema_version": "1",
+    },
+}
+```
+
+The capability should compose existing MIESC pieces:
+
+- `OracleFeedHardeningPlan` supplies price-source trust and freshness context.
+- `FinancialMathPrecisionHardeningPlan` supplies formula, scale, rounding, and
+  index-drift risks.
+- `EconomicAttackPlan` supplies capital, cost, slippage, and profit assumptions.
+- `SequenceOraclePlan` supplies borrow/repay/liquidate/accrue ordering.
+- `SnapshotFuzzingPlan` supplies near-threshold and stale-state seeds.
+- `SemanticGraphGate` supplies market, account, oracle, and liquidation anchors.
+- `SlithIR SSA + Interprocedural State/Taint Summary` supplies precise reads and
+  writes for collateral, debt, reserve, and liquidation state.
+- `PrivilegedGovernanceLifecyclePlan` supplies configuration authority and
+  emergency market controls.
+- `ResourceLivenessGriefingPlan` supplies recovery checks for paused or
+  unliquidatable markets.
+
+## Prompt Requirements
+
+Prompt and parser design must refer to an **interchangeable security reasoning agent**.
+No schema, parser, prompt, or test may bind the capability to a specific vendor,
+hosted endpoint, product family, or model.
+
+The reasoning agent must:
+
+- Separate observed accounting surfaces from inferred solvency risk.
+- Anchor each market, price read, debt update, collateral update, liquidation
+  action, and reserve update to source lines when available.
+- Return at least one negative check for every hypothesis.
+- Prefer executable solvency oracles over narrative severity.
+- Keep oracle, math, governance, and economic assumptions explicit.
+- Avoid confirmed-finding language until validation confirms reachability.
+- Support deterministic local fallback based on borrow/repay/liquidate/accrue/
+  collateral/debt/oracle naming and Slither-derived state writes.
+
+## False-Positive Controls
+
+The capability must avoid noisy lending findings:
+
+- A borrow path is not a finding when collateral checks use fresh, bounded,
+  normalized prices and conservative thresholds.
+- A withdrawal path is not a finding when it rechecks health after interest and
+  price updates.
+- Liquidation complexity is not a finding when close factor, bonus, rounding,
+  and seize math preserve or improve solvency.
+- Stale price risk is not duplicated when it is already fully owned by an
+  oracle-feed plan and has no solvency impact.
+- Rounding risk is not duplicated when it is already fully owned by a financial
+  math plan and has no threshold-flip consequence.
+- Paused markets are not findings when liquidation, repay, and emergency
+  recovery remain available.
+- Bad-debt accounting is not a finding when debt is written off exactly once and
+  reserves or socialized loss are explicit.
+- Governance-controlled risk parameters are not findings without an unsafe
+  transition, missing delay, or critical solvency consequence.
+- Provider output must be bounded and parser-validated before integration.
+
+Promotion rules:
+
+- `hypothesis`: market model and solvency risk only.
+- `test_generated`: a solvency oracle or liquidation harness exists but has not
+  failed.
+- `counterexample`: fuzzing or symbolic execution demonstrates an unsafe
+  solvency or liquidation transition.
+- `replayed`: deterministic local or fork replay demonstrates insolvent borrow,
+  unsafe withdrawal, blocked liquidation, bad debt drift, or unfair seizure.
+- `rejected`: fresh oracle checks, conservative math, bounded liquidation, safe
+  pause/recovery, or explicit bad-debt handling disproves the risk.
+
+## Non-Goals
+
+- No replacement for oracle-feed hardening.
+- No replacement for financial math precision hardening.
+- No replacement for economic attack simulation or profitability modeling.
+- No claim that all centralized risk-parameter control is a vulnerability.
+- No canonical benchmark update from this SDD alone.
+- No remote-chain dependency in the first implementation.
+- No provider-specific dependency.
+- No confirmed vulnerability without a reachable unsafe state transition.
+
+## Integration Plan
+
+Phase 0 is this SDD. Future work should land in small, testable steps:
+
+1. Add provider-neutral schema contracts and parser tests.
+2. Add local market-model extraction for collateral, debt, price, thresholds,
+   close factors, bonuses, interest indexes, reserves, and bad-debt fields.
+3. Add solvency-critical function classifier for supply/withdraw/borrow/repay/
+   accrue/liquidate/seize/absorb/pause/configure paths.
+4. Add hypothesis generator for unsafe borrow, unsafe withdrawal, liquidation
+   bypass, over/under-seizure, stale price solvency, interest gaps, bad-debt
+   drift, reserve drift, and rounding threshold flips.
+5. Generate solvency oracles for Foundry/Halmos/Echidna/local fixtures.
+6. Add fixtures with safe and unsafe variants for each lending family.
+7. Run only non-canonical probes until benchmark promotion is explicitly
+   approved.
+
+## 50-Activity Parallelization Map
+
+These activities can run across five lanes with disjoint file ownership.
+
+1. Inventory current DeFi detector lending outputs.
+2. Inventory oracle-feed hardening price-source fields.
+3. Inventory financial-math liquidation/health-factor fields.
+4. Inventory economic attack liquidation assumptions.
+5. Inventory benchmark categories that mention liquidation, oracle, or lending.
+6. Define `LendingMarket` schema.
+7. Define `AccountingField` schema.
+8. Define `SolvencyHypothesis` schema.
+9. Define `SolvencyOracle` schema.
+10. Define `LendingSolvencyLiquidationPlan` schema.
+11. Add parser for canonical output key.
+12. Add parser aliases for solvency/liquidation plans.
+13. Add bounded text/list sanitization.
+14. Add no-provider-binding regression tests.
+15. Export public facade symbols.
+16. Detect collateral asset fields.
+17. Detect debt asset fields.
+18. Detect price source reads.
+19. Detect collateral-factor constants.
+20. Detect liquidation-threshold constants.
+21. Detect close-factor constants.
+22. Detect liquidation-bonus constants.
+23. Detect debt indexes and interest accrual.
+24. Detect reserve and protocol-fee accounting.
+25. Detect bad-debt or absorb accounting.
+26. Detect supply/deposit functions.
+27. Detect withdraw/redeem functions.
+28. Detect borrow functions.
+29. Detect repay functions.
+30. Detect liquidate/seize/absorb functions.
+31. Add negative checks for fresh normalized prices.
+32. Add negative checks for post-withdraw health checks.
+33. Add negative checks for monotonic debt indexes.
+34. Add negative checks for bounded close factor and seize math.
+35. Add negative checks for pause-safe repay/liquidation/recovery.
+36. Generate Foundry solvency property metadata.
+37. Generate Halmos health-factor assertion metadata.
+38. Generate Echidna near-threshold sequence metadata.
+39. Generate local fixture obligations.
+40. Bridge market model to semantic graph gates.
+41. Bridge borrow/repay/liquidate sequences to sequence-oracle synthesis.
+42. Bridge near-threshold states to snapshot fuzzing.
+43. Bridge price and accounting math to oracle/math plans.
+44. Add fixture: borrow succeeds past safe LTV.
+45. Add fixture: safe borrow rejects unsafe LTV.
+46. Add fixture: withdrawal makes account insolvent.
+47. Add fixture: liquidation fails after stale price.
+48. Add fixture: liquidation over-seizes collateral.
+49. Add fixture: bad debt double-counts reserves.
+50. Add runbook notes for comparing solvency plans with benchmark findings.
+
+Parallel lanes:
+
+- Lane A: schemas, parser, exports, and provider-neutral tests.
+- Lane B: market model and solvency-critical function extraction.
+- Lane C: solvency hypothesis generation and negative checks.
+- Lane D: solvency-oracle generation and tool metadata bridges.
+- Lane E: fixtures, non-canonical evidence, benchmark comparison, and runbook
+  notes.
+
+## Validation
+
+For this SDD:
+
+```bash
+test -s docs/SDD_LENDING_SOLVENCY_LIQUIDATION_HARDENING_20260811.md
+rg -n "interchangeable security reasoning agent|provider-neutral|50-Activity" docs/SDD_LENDING_SOLVENCY_LIQUIDATION_HARDENING_20260811.md
+git diff --check -- docs/SDD_LENDING_SOLVENCY_LIQUIDATION_HARDENING_20260811.md
+```
+
+Provider/model-name checks should run against the document content during review
+and should return no requirement binding the capability to one provider.
+
+For future implementation:
+
+- Unit tests for market-model extraction.
+- Parser tests for bounded provider-neutral output.
+- Fixtures for unsafe and safe borrow/withdraw/liquidate paths.
+- Local/fork replay tests only when the victim or market source is present.

--- a/docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
+++ b/docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
@@ -6,11 +6,29 @@ Status: Proposed SDD, not implemented, no benchmark claim
 
 ## Signal
 
-MIESC already detects classic access-control symptoms: missing guards on privileged functions, excessive owner power, governance flash-loan patterns, missing timelocks in some admin paths, upgrade/admin drift, and semantic graph gates over role nodes. That coverage is useful, but it is still mostly local: it asks whether a function is guarded or whether a timelock string appears nearby.
+MIESC already covers access-control detectors, upgrade-evolution analysis,
+delegatecall storage aliasing, signature-domain hardening, transaction ordering,
+semantic graph gating, SlithIR SSA summaries, and resource/liveness griefing.
+The remaining gap is not another `onlyOwner` matcher. The gap is a
+provider-neutral artifact that reasons about the **lifecycle of privileged
+authority**: how roles are created, delegated, queued, delayed, revoked,
+renounced, rotated, upgraded, paused, and used under emergency or compromised-key
+conditions.
 
-Modern Solidity systems rely on a lifecycle of authority rather than a single `onlyOwner` modifier. Ownership can transfer in one or two steps, roles can be administered by other roles, timelocks can own controlled contracts, proposers and executors can become unavailable, guardians can pause but not unpause, multisigs can hold high-blast-radius roles, and emergency paths can bypass normal governance. OWASP SC01:2026 explicitly frames access control as more than a single modifier, including governance contracts, multisigs, guardians, proxy admins, and cross-chain routers. OpenZeppelin's TimelockController documentation also highlights the lifecycle risk that role availability and self-administered timelocks can lock controlled contracts indefinitely.
+Smart-contract incidents often happen outside the single guarded function that a
+classic access-control detector sees. A function may be guarded, but the guard
+can be bypassed through an unsafe initializer, instant timelock execution,
+unbounded guardian powers, stale multisig assumptions, pause-only-without-unpause
+design, role admin self-grant paths, upgrade hooks, cross-chain governance
+messages, or governance actions that are valid individually but unsafe as a
+sequence.
 
-The technique to add is **Privileged Governance Lifecycle Hardening**: synthesize an authority graph, model role/admin/timelock transitions over time, classify lifecycle hazards, and generate provider-neutral validation obligations for unauthorized action, unavailable recovery, timelock bypass, overpowered emergency controls, and irreversible privilege loss.
+The technique to add is **Privileged Governance Lifecycle Hardening**: synthesize
+an authority graph and lifecycle plan, then generate validation obligations for
+role-transition sequences, delay invariants, emergency powers, upgrade powers,
+pause/recover flows, and cross-domain governance messages. Plans remain advisory
+until replay, symbolic execution, fuzzing, or human review confirms a reachable
+privilege escalation, governance bypass, or unavailable recovery path.
 
 ## Spec/Goal
 
@@ -29,21 +47,37 @@ privileged_governance_lifecycle_plans
 Suggested aliases:
 
 ```text
-authority_lifecycle_hardening
-governance_privilege_hardening
-role_timelock_lifecycle
-admin_blast_radius_hardening
+governance_lifecycle_hardening
+privileged_role_lifecycle_plans
+authority_graph_hardening
+admin_timelock_hardening
+emergency_power_hardening
 ```
 
-The capability must produce advisory lifecycle plans, not confirmed findings. It should promote a finding only after deterministic evidence, generated tests, symbolic counterexamples, or human review confirms that a privileged action can be abused, bypassed, locked forever, or recovered only through unsafe assumptions.
+The capability must produce advisory governance lifecycle plans, not confirmed
+findings. A plan becomes a finding only after deterministic replay, symbolic
+execution, fuzzing, local fixture validation, fork validation, or human review
+confirms the unsafe state transition or missing recovery path.
 
 Primary objectives:
 
-1. Extract privileged entrypoints: pause/unpause, mint/burn, set parameters, withdraw reserves, upgrade, grant/revoke roles, queue/execute/cancel proposals, emergency actions, and cross-chain admin relay.
-2. Build an authority graph of owners, roles, role admins, timelocks, governors, guardians, proxy admins, multisigs, and controlled contracts.
-3. Model lifecycle transitions: ownership transfer, role grant/revoke, timelock queue/execute/cancel, delay changes, pauser/unpauser separation, emergency bypass, upgrade admin handoff, and renounce/recovery paths.
-4. Generate validation obligations for unauthorized execution, timelock bypass, role escalation, dead-admin lockout, guardian overreach, impossible unpause, unsafe delay reduction, and high-blast-radius single key.
-5. Keep false-positive controls for intentionally centralized deployments, documented launch phases, bounded guardian powers, multisig/timelock controls, and explicit break-glass procedures.
+1. Identify privileged actors: owner, admin, guardian, governor, proposer,
+   executor, pauser, upgrader, bridge messenger, timelock, multisig, keeper, and
+   role-admin relationships.
+2. Identify privileged surfaces: upgrade, pause/unpause, mint/burn, treasury
+   movement, oracle setter, fee setter, parameter setter, role grant/revoke,
+   emergency withdrawal, bridge relay, proposal queue/execute/cancel, and
+   initializer/reinitializer functions.
+3. Build lifecycle transitions: bootstrap, initialization, delegation, role
+   rotation, timelock queue, timelock execute, cancellation, pause, unpause,
+   emergency recovery, upgrade, migration, decommission, and renounce.
+4. Infer governance invariants: no unprotected initializer, admin cannot
+   self-grant without delay, critical changes require timelock, emergency powers
+   are bounded, pause has a recovery path, upgrades preserve authority, and
+   cross-domain governance messages bind sender/domain/replay state.
+5. Generate validation obligations that exercise role-transition sequences and
+   reject false positives when controls are explicit, delayed, bounded, and
+   recoverable.
 
 ## Design/Contract
 
@@ -54,36 +88,54 @@ PrivilegedGovernanceLifecyclePlan = {
     "id": "string",
     "objective": "string",
     "authority_graph": {
-        "privileged_entrypoints": ["function"],
-        "authority_nodes": ["owner|role|role_admin|timelock|governor|guardian|proxy_admin|multisig|cross_chain_router|unknown"],
-        "controlled_contracts": ["string"],
+        "actors": [
+            {
+                "id": "string",
+                "kind": "owner|admin|guardian|governor|proposer|executor|pauser|upgrader|timelock|multisig|bridge_messenger|keeper|unknown",
+                "source": "storage|constant|constructor|initializer|role|external_contract|unknown",
+                "source_anchors": ["file:line"],
+            }
+        ],
+        "roles": [
+            {
+                "name": "string",
+                "admin_role": "string",
+                "holders": ["actor_id"],
+                "grant_functions": ["function"],
+                "revoke_functions": ["function"],
+            }
+        ],
         "edges": [
             {
-                "source": "string",
-                "target": "string",
-                "relation": "owns|administers|queues|executes|cancels|pauses|unpauses|upgrades|grants|revokes|relays",
-                "source_anchor": "file:line",
+                "source": "actor_or_role",
+                "target": "function_or_role",
+                "relation": "guards|grants|revokes|queues|executes|cancels|upgrades|pauses|recovers|delegates",
+                "evidence": ["string"],
             }
         ],
     },
     "lifecycle_hypothesis": {
-        "category": "unguarded_privilege|role_escalation|timelock_bypass|unsafe_delay_change|dead_admin_lockout|guardian_overreach|impossible_recovery|pause_deadlock|upgrade_admin_drift|single_key_high_blast_radius|cross_chain_admin_spoof",
-        "privileged_action": "string",
-        "actor_model": "string",
+        "category": "unprotected_initializer|role_admin_self_grant|missing_timelock|timelock_bypass|unbounded_emergency_power|pause_recovery_gap|unsafe_upgrade_authority|cross_domain_governance_replay|guardian_takeover|renounce_brick|parameter_rug|treasury_drain_path",
+        "attacker_or_fault_model": "string",
+        "unsafe_transition": "string",
+        "critical_surface": "string",
         "preconditions": ["string"],
         "negative_checks": ["string"],
-        "blast_radius": ["string"],
     },
-    "validation_obligations": [
-        {
-            "tool": "foundry|echidna|halmos|local_fixture|human_review",
-            "property": "string",
-            "sequence": ["call"],
-            "actors": ["attacker", "owner", "guardian", "governor", "proposer", "executor", "admin"],
-            "expected_failure_or_revert": "string",
-            "recovery_check": "string",
-        }
-    ],
+    "governance_oracle": {
+        "property": "string",
+        "expected_safe_transition": "string",
+        "forbidden_transition": "string",
+        "recovery_condition": "string",
+    },
+    "execution_plan": {
+        "recommended_tools": ["foundry", "halmos", "echidna", "slither", "openzeppelin-upgrades", "local_fixture", "human_review"],
+        "sequence": ["call"],
+        "actors": ["deployer", "admin", "attacker", "guardian", "governor", "executor", "user"],
+        "inputs_to_mutate": ["string"],
+        "delay_budget_hint": "string",
+        "fork_or_timewarp_hint": "string",
+    },
     "promotion": {
         "state": "hypothesis|test_generated|counterexample|replayed|rejected",
         "evidence": ["string"],
@@ -98,131 +150,164 @@ PrivilegedGovernanceLifecyclePlan = {
 
 The capability should compose existing MIESC pieces:
 
-- Classic access-control detectors remain first-pass signals for missing guards.
-- Governance and centralization detectors supply suspicious privileged surfaces.
-- `SemanticGraphGate` supplies role, modifier, event, external-call, and state anchors.
-- `SequenceOraclePlan` can validate multi-step queue/execute/cancel/grant/revoke lifecycles.
-- `Metamorphic Diff Testing` can validate pause/config/idempotence behavior.
-- `Upgrade Evolution Analysis` can supply admin handoff and proxy-admin drift context.
-- `Resource/Liveness Griefing Hardening` can consume pause deadlocks and dead-admin lockouts.
-- False-positive filtering must downgrade local `onlyOwner` findings when documented timelock, multisig, role segmentation, and recovery paths are present.
+- Access-control findings provide guard and missing-guard seeds.
+- `UpgradeEvolutionPlan` supplies storage-layout and upgrade-authority changes.
+- `DelegatecallStorageAliasingPlan` supplies privileged-slot corruption paths.
+- `SignatureDomainHardeningPlan` supplies off-chain authorization and replay
+  surfaces.
+- `CrossChainMessageHardeningPlan` supplies cross-domain sender/domain/replay
+  checks.
+- `SequenceOraclePlan` supplies role-transition ordering.
+- `SnapshotFuzzingPlan` supplies reusable governance states and delay/queue
+  waypoints.
+- `SemanticGraphGate` supplies authority graph anchors.
+- `SlithIR SSA + Interprocedural State/Taint Summary` supplies precise
+  role-variable writes and privileged call propagation.
+- `ResourceLivenessGriefingPlan` supplies pause/recover and keeper-liveness
+  recovery checks.
 
 ## Prompt Requirements
 
-Prompt and parser design must refer to an **interchangeable security reasoning agent**. No schema, parser, prompt, test, or SDD requirement may bind the capability to a specific vendor, hosted endpoint, product family, or model.
+Prompt and parser design must refer to an **interchangeable security reasoning agent**.
+No schema, parser, prompt, or test may bind the capability to a
+specific vendor, hosted endpoint, product family, or model.
 
 The reasoning agent must:
 
-- Separate observed authority edges from inferred lifecycle hazards.
-- Anchor every privileged entrypoint and authority edge to source lines.
-- Include negative checks for each lifecycle hypothesis.
-- Identify blast radius, not only access-control category.
-- Avoid confirmed-finding language until validation confirms abuse, bypass, lockout, or unrecoverable privilege loss.
-- Support deterministic local fallback based on modifiers, role constants, events, timelock functions, and ownership-transfer patterns.
+- Separate observed authority relationships from inferred governance risk.
+- Anchor each actor, role, privileged function, and lifecycle transition to
+  source lines when available.
+- Return at least one negative check for every hypothesis.
+- Prefer executable governance oracles over narrative severity.
+- Keep emergency controls and governance delays explicit.
+- Avoid confirmed-finding language until validation confirms reachability.
+- Support deterministic local fallback based on owner/admin/role/timelock/
+  upgrade/pause naming and Slither-derived state writes.
 
 ## False-Positive Controls
 
 The capability must avoid noisy governance findings:
 
-- A single owner during launch is not a finding unless the deployment phase is indistinguishable from production or the blast radius is unmanaged.
-- A guardian is not overpowered when it can pause only, cannot drain/upgrade, and unpause/recovery is governed.
-- A timelock is not protection unless privileged actions are actually routed through it and delay changes cannot be immediate.
-- Self-administered timelocks are not automatically unsafe, but role availability and recovery must be modeled.
-- Multisig references are advisory until signer threshold, owner path, and controlled action surface are known.
-- Role grants are not escalation findings when role admins are properly separated and recoverable.
+- A privileged function is not a finding when its authority is explicit,
+  expected, delayed, and documented.
+- Admin self-grant is not a finding when it is timelocked, quorum-controlled, or
+  bounded by a multisig/governor path with cancellation.
+- Emergency pause is not a finding when pause duration, unpause authority, and
+  recovery flow are bounded.
+- Upgrade authority is not a governance finding when upgrade authorization,
+  storage compatibility, initializer safety, and migration checks are enforced.
+- Renounce ownership is not a finding when a replacement owner/governor/recovery
+  path exists before renounce.
+- Cross-domain governance is not a finding when sender, chain/domain, nonce,
+  replay protection, and finality delay are verified.
+- Parameter changes are not findings without a critical economic, accounting,
+  oracle, fee, liquidation, mint/burn, treasury, or access-control consequence.
 - Provider output must be bounded and parser-validated before integration.
 
 Promotion rules:
 
 - `hypothesis`: authority graph and lifecycle risk only.
-- `test_generated`: a validation sequence exists but has no failing execution.
-- `counterexample`: symbolic/fuzz/local execution demonstrates bypass, escalation, lockout, or unsafe recovery.
-- `replayed`: deterministic local or fork replay demonstrates impact.
-- `rejected`: timelock routing, multisig controls, role separation, bounded emergency powers, and recovery paths disprove the risk.
+- `test_generated`: a governance oracle or role-transition harness exists but
+  has not failed.
+- `counterexample`: fuzzing or symbolic execution demonstrates an unsafe
+  transition.
+- `replayed`: deterministic local or fork replay demonstrates privilege
+  escalation, bypass, stuck recovery, or unauthorized critical action.
+- `rejected`: timelock, quorum, cancellation, bounded emergency power, safe
+  upgrade guard, or recovery path disproves the risk.
 
 ## Non-Goals
 
 - No replacement for classic access-control detectors.
-- No generic centralization score.
+- No claim that every centralized admin surface is a vulnerability.
 - No canonical benchmark update from this SDD alone.
-- No assumption that every admin key is a vulnerability.
+- No remote governance service dependency in the first implementation.
 - No provider-specific dependency.
-- No confirmed finding from a local modifier pattern alone.
+- No confirmed vulnerability without a reachable unsafe transition.
 
 ## Integration Plan
 
 Phase 0 is this SDD. Future work should land in small, testable steps:
 
 1. Add provider-neutral schema contracts and parser tests.
-2. Add local authority graph extraction for owners, roles, role admins, timelocks, governors, guardians, proxy admins, and cross-chain routers.
-3. Add lifecycle transition extraction for transfer, accept, grant, revoke, queue, execute, cancel, pause, unpause, delay change, upgrade, and emergency functions.
-4. Add local lifecycle hazard classifier with negative checks.
-5. Generate validation obligations for Foundry, Echidna, Halmos, local fixtures, and human review.
-6. Add fixtures with safe and unsafe variants for each lifecycle family.
-7. Run only non-canonical probes until benchmark promotion is explicitly approved.
+2. Add local authority-graph extraction for owners, roles, timelocks, governors,
+   guardians, pausers, upgraders, and bridge messengers.
+3. Add privileged-surface classifier for upgrade/pause/treasury/oracle/fee/
+   role/initializer/emergency paths.
+4. Add lifecycle hypothesis generator for unsafe initialization, role-admin
+   self-grant, missing timelock, timelock bypass, unbounded emergency power,
+   pause recovery gaps, unsafe upgrade authority, cross-domain replay, and
+   parameter rug paths.
+5. Generate governance oracles for Foundry/Halmos/Echidna/local fixtures.
+6. Add fixtures with safe and unsafe variants for role transition, timelock,
+   pause/unpause, upgrade, and cross-domain governance families.
+7. Run only non-canonical probes until benchmark promotion is explicitly
+   approved.
 
 ## 50-Activity Parallelization Map
 
 These activities can run across five lanes with disjoint file ownership.
 
 1. Inventory current access-control detector outputs.
-2. Inventory governance detector outputs.
-3. Inventory centralization detector outputs.
-4. Inventory upgrade/admin handoff outputs.
-5. Inventory semantic graph role/modifier nodes.
-6. Define `AuthorityNode` schema.
-7. Define `AuthorityEdge` schema.
-8. Define `PrivilegedEntrypoint` schema.
-9. Define `LifecycleTransition` schema.
+2. Inventory upgrade-evolution authority fields.
+3. Inventory delegatecall privileged-slot findings.
+4. Inventory signature-domain authority surfaces.
+5. Inventory cross-chain governance message checks.
+6. Define `GovernanceActor` schema.
+7. Define `GovernanceRole` schema.
+8. Define `AuthorityGraphEdge` schema.
+9. Define `LifecycleHypothesis` schema.
 10. Define `PrivilegedGovernanceLifecyclePlan` schema.
 11. Add parser for canonical output key.
-12. Add aliases for authority lifecycle plans.
+12. Add parser aliases for governance lifecycle plans.
 13. Add bounded text/list sanitization.
 14. Add no-provider-binding regression tests.
 15. Export public facade symbols.
-16. Detect Ownable ownership surfaces.
-17. Detect Ownable2Step transfer/accept paths.
-18. Detect AccessControl role constants.
-19. Detect role admin relationships.
-20. Detect TimelockController queue/execute/cancel paths.
-21. Detect Governor proposal execution paths.
-22. Detect guardian pause/unpause surfaces.
-23. Detect proxy admin/upgrade surfaces.
-24. Detect multisig references and threshold hints.
-25. Detect cross-chain admin relay surfaces.
-26. Detect unguarded privileged entrypoints.
-27. Detect role escalation via grant/revoke admin loops.
-28. Detect timelock bypass on privileged calls.
-29. Detect unsafe delay reduction.
-30. Detect dead-admin lockout risk.
-31. Detect guardian overreach.
-32. Detect impossible unpause/recovery paths.
-33. Detect pause deadlocks.
-34. Detect upgrade admin drift.
-35. Detect high-blast-radius single key.
-36. Add negative checks for timelock routing.
-37. Add negative checks for multisig/threshold controls.
-38. Add negative checks for role separation.
-39. Add negative checks for bounded guardian powers.
-40. Add negative checks for documented recovery paths.
-41. Generate Foundry authorization/lifecycle sequences.
-42. Generate Echidna privilege invariants.
-43. Generate Halmos assertion metadata.
-44. Bridge authority graph to semantic graph gates.
-45. Bridge pause deadlocks to liveness hardening.
-46. Bridge admin handoff to upgrade evolution.
-47. Add unsafe fixture for immediate delay reduction.
-48. Add safe fixture for timelocked delay update.
-49. Add unsafe fixture for guardian drain/upgrade.
-50. Add safe fixture for pause-only guardian and governed recovery.
+16. Detect owner/admin storage variables.
+17. Detect OpenZeppelin-style roles and role admins.
+18. Detect timelock controllers and queue/execute/cancel paths.
+19. Detect governor proposer/executor paths.
+20. Detect pauser/guardian/emergency roles.
+21. Detect upgrader and proxy admin paths.
+22. Detect initializer/reinitializer authority setup.
+23. Detect bridge messenger governance sources.
+24. Detect treasury and fee setter surfaces.
+25. Detect oracle and risk-parameter setter surfaces.
+26. Detect role grant/revoke functions.
+27. Detect renounce/transfer ownership transitions.
+28. Detect missing delay on critical transitions.
+29. Detect missing cancellation on queued actions.
+30. Detect missing unpause/recovery path.
+31. Add negative checks for explicit timelocks.
+32. Add negative checks for quorum and multisig paths.
+33. Add negative checks for bounded emergency powers.
+34. Add negative checks for safe initializer guards.
+35. Add negative checks for cross-domain replay protection.
+36. Generate Foundry role-transition property metadata.
+37. Generate Halmos authorization assertion metadata.
+38. Generate Echidna governance sequence metadata.
+39. Generate local fixture obligations.
+40. Bridge authority graph edges to semantic graph gates.
+41. Bridge role-transition sequences to sequence-oracle synthesis.
+42. Bridge delayed-state seeds to snapshot fuzzing.
+43. Bridge authority writes to SSA/taint summaries.
+44. Add fixture: unprotected initializer grants owner.
+45. Add fixture: safe initializer guard rejects second call.
+46. Add fixture: admin self-grant bypasses timelock.
+47. Add fixture: safe timelock queue/execute/cancel path.
+48. Add fixture: pause without recovery bricks withdrawal.
+49. Add fixture: safe guardian pause with governor unpause.
+50. Add runbook notes for comparing governance lifecycle plans with benchmark
+    findings.
 
 Parallel lanes:
 
 - Lane A: schemas, parser, exports, and provider-neutral tests.
-- Lane B: authority graph and lifecycle transition extraction.
-- Lane C: hazard classifiers and negative checks.
-- Lane D: validation obligations and bridges to existing plans.
-- Lane E: fixtures, non-canonical evidence, benchmark comparison, and runbook notes.
+- Lane B: authority graph and privileged surface extraction.
+- Lane C: lifecycle hypothesis generation and negative checks.
+- Lane D: governance-oracle generation and tool metadata bridges.
+- Lane E: fixtures, non-canonical evidence, benchmark comparison, and runbook
+  notes.
 
 ## Validation
 
@@ -234,23 +319,12 @@ rg -n "interchangeable security reasoning agent|provider-neutral|50-Activity" do
 git diff --check -- docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
 ```
 
-Provider/model-name checks should run against the document content during review and should return no requirement binding the capability to one provider.
+Provider/model-name checks should run against the document content during review
+and should return no requirement binding the capability to one provider.
 
 For future implementation:
 
-- Unit tests for authority graph and lifecycle transition extraction.
+- Unit tests for authority graph extraction.
 - Parser tests for bounded provider-neutral output.
-- Fixture tests for unsafe and safe variants of each lifecycle family.
-- Integration tests proving local access-control findings stay advisory without lifecycle evidence.
-- Non-canonical benchmark probes before any claimed uplift.
-
-## References
-
-- OWASP SC01:2026 Access Control Vulnerabilities. https://scs.owasp.org/sctop10/SC01-AccessControlVulnerabilities/
-- OWASP SCWE-020: Absence of Time-Locked Functions. https://scs.owasp.org/SCWE/SCSVS-AUTH/SCWE-020/
-- OpenZeppelin Contracts Access Control. https://docs.openzeppelin.com/contracts/5.x/api/access
-- OpenZeppelin Contracts Governance and TimelockController. https://docs.openzeppelin.com/contracts/4.x/api/governance
-- OpenZeppelin Timelock role management guide. https://docs.openzeppelin.com/defender/guide/timelock-roles
-- Local reference: `docs/SDD_SEMANTIC_GRAPH_GATING_20260709.md`
-- Local reference: `docs/SDD_UPGRADE_EVOLUTION_ANALYSIS_20260711.md`
-- Local reference: `docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md`
+- Fixtures for unsafe and safe role-transition paths.
+- Local/fork replay tests only when the victim or governance source is present.

--- a/docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
+++ b/docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
@@ -1,0 +1,256 @@
+# SDD: Privileged Governance Lifecycle Hardening
+
+Date: 2026-08-11
+Owner/Lane: Codex
+Status: Proposed SDD, not implemented, no benchmark claim
+
+## Signal
+
+MIESC already detects classic access-control symptoms: missing guards on privileged functions, excessive owner power, governance flash-loan patterns, missing timelocks in some admin paths, upgrade/admin drift, and semantic graph gates over role nodes. That coverage is useful, but it is still mostly local: it asks whether a function is guarded or whether a timelock string appears nearby.
+
+Modern Solidity systems rely on a lifecycle of authority rather than a single `onlyOwner` modifier. Ownership can transfer in one or two steps, roles can be administered by other roles, timelocks can own controlled contracts, proposers and executors can become unavailable, guardians can pause but not unpause, multisigs can hold high-blast-radius roles, and emergency paths can bypass normal governance. OWASP SC01:2026 explicitly frames access control as more than a single modifier, including governance contracts, multisigs, guardians, proxy admins, and cross-chain routers. OpenZeppelin's TimelockController documentation also highlights the lifecycle risk that role availability and self-administered timelocks can lock controlled contracts indefinitely.
+
+The technique to add is **Privileged Governance Lifecycle Hardening**: synthesize an authority graph, model role/admin/timelock transitions over time, classify lifecycle hazards, and generate provider-neutral validation obligations for unauthorized action, unavailable recovery, timelock bypass, overpowered emergency controls, and irreversible privilege loss.
+
+## Spec/Goal
+
+Add a future capability named:
+
+```text
+privileged_governance_lifecycle_hardening
+```
+
+Expected output key:
+
+```text
+privileged_governance_lifecycle_plans
+```
+
+Suggested aliases:
+
+```text
+authority_lifecycle_hardening
+governance_privilege_hardening
+role_timelock_lifecycle
+admin_blast_radius_hardening
+```
+
+The capability must produce advisory lifecycle plans, not confirmed findings. It should promote a finding only after deterministic evidence, generated tests, symbolic counterexamples, or human review confirms that a privileged action can be abused, bypassed, locked forever, or recovered only through unsafe assumptions.
+
+Primary objectives:
+
+1. Extract privileged entrypoints: pause/unpause, mint/burn, set parameters, withdraw reserves, upgrade, grant/revoke roles, queue/execute/cancel proposals, emergency actions, and cross-chain admin relay.
+2. Build an authority graph of owners, roles, role admins, timelocks, governors, guardians, proxy admins, multisigs, and controlled contracts.
+3. Model lifecycle transitions: ownership transfer, role grant/revoke, timelock queue/execute/cancel, delay changes, pauser/unpauser separation, emergency bypass, upgrade admin handoff, and renounce/recovery paths.
+4. Generate validation obligations for unauthorized execution, timelock bypass, role escalation, dead-admin lockout, guardian overreach, impossible unpause, unsafe delay reduction, and high-blast-radius single key.
+5. Keep false-positive controls for intentionally centralized deployments, documented launch phases, bounded guardian powers, multisig/timelock controls, and explicit break-glass procedures.
+
+## Design/Contract
+
+Introduce a provider-neutral data contract before implementation:
+
+```python
+PrivilegedGovernanceLifecyclePlan = {
+    "id": "string",
+    "objective": "string",
+    "authority_graph": {
+        "privileged_entrypoints": ["function"],
+        "authority_nodes": ["owner|role|role_admin|timelock|governor|guardian|proxy_admin|multisig|cross_chain_router|unknown"],
+        "controlled_contracts": ["string"],
+        "edges": [
+            {
+                "source": "string",
+                "target": "string",
+                "relation": "owns|administers|queues|executes|cancels|pauses|unpauses|upgrades|grants|revokes|relays",
+                "source_anchor": "file:line",
+            }
+        ],
+    },
+    "lifecycle_hypothesis": {
+        "category": "unguarded_privilege|role_escalation|timelock_bypass|unsafe_delay_change|dead_admin_lockout|guardian_overreach|impossible_recovery|pause_deadlock|upgrade_admin_drift|single_key_high_blast_radius|cross_chain_admin_spoof",
+        "privileged_action": "string",
+        "actor_model": "string",
+        "preconditions": ["string"],
+        "negative_checks": ["string"],
+        "blast_radius": ["string"],
+    },
+    "validation_obligations": [
+        {
+            "tool": "foundry|echidna|halmos|local_fixture|human_review",
+            "property": "string",
+            "sequence": ["call"],
+            "actors": ["attacker", "owner", "guardian", "governor", "proposer", "executor", "admin"],
+            "expected_failure_or_revert": "string",
+            "recovery_check": "string",
+        }
+    ],
+    "promotion": {
+        "state": "hypothesis|test_generated|counterexample|replayed|rejected",
+        "evidence": ["string"],
+        "blockers": ["string"],
+    },
+    "metadata": {
+        "capability": "privileged_governance_lifecycle_hardening",
+        "schema_version": "1",
+    },
+}
+```
+
+The capability should compose existing MIESC pieces:
+
+- Classic access-control detectors remain first-pass signals for missing guards.
+- Governance and centralization detectors supply suspicious privileged surfaces.
+- `SemanticGraphGate` supplies role, modifier, event, external-call, and state anchors.
+- `SequenceOraclePlan` can validate multi-step queue/execute/cancel/grant/revoke lifecycles.
+- `Metamorphic Diff Testing` can validate pause/config/idempotence behavior.
+- `Upgrade Evolution Analysis` can supply admin handoff and proxy-admin drift context.
+- `Resource/Liveness Griefing Hardening` can consume pause deadlocks and dead-admin lockouts.
+- False-positive filtering must downgrade local `onlyOwner` findings when documented timelock, multisig, role segmentation, and recovery paths are present.
+
+## Prompt Requirements
+
+Prompt and parser design must refer to an **interchangeable security reasoning agent**. No schema, parser, prompt, test, or SDD requirement may bind the capability to a specific vendor, hosted endpoint, product family, or model.
+
+The reasoning agent must:
+
+- Separate observed authority edges from inferred lifecycle hazards.
+- Anchor every privileged entrypoint and authority edge to source lines.
+- Include negative checks for each lifecycle hypothesis.
+- Identify blast radius, not only access-control category.
+- Avoid confirmed-finding language until validation confirms abuse, bypass, lockout, or unrecoverable privilege loss.
+- Support deterministic local fallback based on modifiers, role constants, events, timelock functions, and ownership-transfer patterns.
+
+## False-Positive Controls
+
+The capability must avoid noisy governance findings:
+
+- A single owner during launch is not a finding unless the deployment phase is indistinguishable from production or the blast radius is unmanaged.
+- A guardian is not overpowered when it can pause only, cannot drain/upgrade, and unpause/recovery is governed.
+- A timelock is not protection unless privileged actions are actually routed through it and delay changes cannot be immediate.
+- Self-administered timelocks are not automatically unsafe, but role availability and recovery must be modeled.
+- Multisig references are advisory until signer threshold, owner path, and controlled action surface are known.
+- Role grants are not escalation findings when role admins are properly separated and recoverable.
+- Provider output must be bounded and parser-validated before integration.
+
+Promotion rules:
+
+- `hypothesis`: authority graph and lifecycle risk only.
+- `test_generated`: a validation sequence exists but has no failing execution.
+- `counterexample`: symbolic/fuzz/local execution demonstrates bypass, escalation, lockout, or unsafe recovery.
+- `replayed`: deterministic local or fork replay demonstrates impact.
+- `rejected`: timelock routing, multisig controls, role separation, bounded emergency powers, and recovery paths disprove the risk.
+
+## Non-Goals
+
+- No replacement for classic access-control detectors.
+- No generic centralization score.
+- No canonical benchmark update from this SDD alone.
+- No assumption that every admin key is a vulnerability.
+- No provider-specific dependency.
+- No confirmed finding from a local modifier pattern alone.
+
+## Integration Plan
+
+Phase 0 is this SDD. Future work should land in small, testable steps:
+
+1. Add provider-neutral schema contracts and parser tests.
+2. Add local authority graph extraction for owners, roles, role admins, timelocks, governors, guardians, proxy admins, and cross-chain routers.
+3. Add lifecycle transition extraction for transfer, accept, grant, revoke, queue, execute, cancel, pause, unpause, delay change, upgrade, and emergency functions.
+4. Add local lifecycle hazard classifier with negative checks.
+5. Generate validation obligations for Foundry, Echidna, Halmos, local fixtures, and human review.
+6. Add fixtures with safe and unsafe variants for each lifecycle family.
+7. Run only non-canonical probes until benchmark promotion is explicitly approved.
+
+## 50-Activity Parallelization Map
+
+These activities can run across five lanes with disjoint file ownership.
+
+1. Inventory current access-control detector outputs.
+2. Inventory governance detector outputs.
+3. Inventory centralization detector outputs.
+4. Inventory upgrade/admin handoff outputs.
+5. Inventory semantic graph role/modifier nodes.
+6. Define `AuthorityNode` schema.
+7. Define `AuthorityEdge` schema.
+8. Define `PrivilegedEntrypoint` schema.
+9. Define `LifecycleTransition` schema.
+10. Define `PrivilegedGovernanceLifecyclePlan` schema.
+11. Add parser for canonical output key.
+12. Add aliases for authority lifecycle plans.
+13. Add bounded text/list sanitization.
+14. Add no-provider-binding regression tests.
+15. Export public facade symbols.
+16. Detect Ownable ownership surfaces.
+17. Detect Ownable2Step transfer/accept paths.
+18. Detect AccessControl role constants.
+19. Detect role admin relationships.
+20. Detect TimelockController queue/execute/cancel paths.
+21. Detect Governor proposal execution paths.
+22. Detect guardian pause/unpause surfaces.
+23. Detect proxy admin/upgrade surfaces.
+24. Detect multisig references and threshold hints.
+25. Detect cross-chain admin relay surfaces.
+26. Detect unguarded privileged entrypoints.
+27. Detect role escalation via grant/revoke admin loops.
+28. Detect timelock bypass on privileged calls.
+29. Detect unsafe delay reduction.
+30. Detect dead-admin lockout risk.
+31. Detect guardian overreach.
+32. Detect impossible unpause/recovery paths.
+33. Detect pause deadlocks.
+34. Detect upgrade admin drift.
+35. Detect high-blast-radius single key.
+36. Add negative checks for timelock routing.
+37. Add negative checks for multisig/threshold controls.
+38. Add negative checks for role separation.
+39. Add negative checks for bounded guardian powers.
+40. Add negative checks for documented recovery paths.
+41. Generate Foundry authorization/lifecycle sequences.
+42. Generate Echidna privilege invariants.
+43. Generate Halmos assertion metadata.
+44. Bridge authority graph to semantic graph gates.
+45. Bridge pause deadlocks to liveness hardening.
+46. Bridge admin handoff to upgrade evolution.
+47. Add unsafe fixture for immediate delay reduction.
+48. Add safe fixture for timelocked delay update.
+49. Add unsafe fixture for guardian drain/upgrade.
+50. Add safe fixture for pause-only guardian and governed recovery.
+
+Parallel lanes:
+
+- Lane A: schemas, parser, exports, and provider-neutral tests.
+- Lane B: authority graph and lifecycle transition extraction.
+- Lane C: hazard classifiers and negative checks.
+- Lane D: validation obligations and bridges to existing plans.
+- Lane E: fixtures, non-canonical evidence, benchmark comparison, and runbook notes.
+
+## Validation
+
+For this SDD:
+
+```bash
+test -s docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
+rg -n "interchangeable security reasoning agent|provider-neutral|50-Activity" docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
+git diff --check -- docs/SDD_PRIVILEGED_GOVERNANCE_LIFECYCLE_HARDENING_20260811.md
+```
+
+Provider/model-name checks should run against the document content during review and should return no requirement binding the capability to one provider.
+
+For future implementation:
+
+- Unit tests for authority graph and lifecycle transition extraction.
+- Parser tests for bounded provider-neutral output.
+- Fixture tests for unsafe and safe variants of each lifecycle family.
+- Integration tests proving local access-control findings stay advisory without lifecycle evidence.
+- Non-canonical benchmark probes before any claimed uplift.
+
+## References
+
+- OWASP SC01:2026 Access Control Vulnerabilities. https://scs.owasp.org/sctop10/SC01-AccessControlVulnerabilities/
+- OWASP SCWE-020: Absence of Time-Locked Functions. https://scs.owasp.org/SCWE/SCSVS-AUTH/SCWE-020/
+- OpenZeppelin Contracts Access Control. https://docs.openzeppelin.com/contracts/5.x/api/access
+- OpenZeppelin Contracts Governance and TimelockController. https://docs.openzeppelin.com/contracts/4.x/api/governance
+- OpenZeppelin Timelock role management guide. https://docs.openzeppelin.com/defender/guide/timelock-roles
+- Local reference: `docs/SDD_SEMANTIC_GRAPH_GATING_20260709.md`
+- Local reference: `docs/SDD_UPGRADE_EVOLUTION_ANALYSIS_20260711.md`
+- Local reference: `docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md`

--- a/docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md
+++ b/docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md
@@ -1,0 +1,254 @@
+# SDD: Resource/Liveness Griefing Hardening
+
+Date: 2026-08-11
+Owner/Lane: Codex
+Status: Proposed SDD, not implemented, no benchmark claim
+
+## Signal
+
+MIESC already has classic DoS detectors, cross-function DoS heuristics, RAG records for gas-limit and failed-call griefing, external-call returndata hardening, sequence-oracle plans, snapshot fuzzing guidance, semantic graph gates, and invariant validation. The remaining gap is not another local regex for `for (...)` or `.transfer(...)`. The gap is a provider-neutral artifact that reasons about **progress**: whether an honest actor can eventually withdraw, settle, claim, process, liquidate, execute, or recover even when an attacker bloats state, reverts callbacks, withholds keeper actions, manipulates gas, or forces partial failure.
+
+The current v6.0.0 SmartBugs report also gives local signal: `denial_of_service` remains a real recall gap at 37.50% recall in the static-only slice. Existing detectors find obvious loops and push-payment patterns, but MIESC does not yet expose a structured capability that connects growth provenance, bounded batch progress, fallback actors, failed external calls, and liveness oracles.
+
+The technique to add is **Resource/Liveness Griefing Hardening**: synthesize resource-growth and progress invariants, generate validation obligations for fuzzing/symbolic/local fixtures, and keep hypotheses advisory until a counterexample demonstrates stuck funds, blocked settlement, unbounded gas growth, or unavailable protocol progress.
+
+## Spec/Goal
+
+Add a future capability named:
+
+```text
+resource_liveness_griefing_hardening
+```
+
+Expected output key:
+
+```text
+resource_liveness_griefing_plans
+```
+
+Suggested aliases:
+
+```text
+dos_liveness_hardening
+resource_griefing_hardening
+liveness_oracle_synthesis
+progress_invariant_hardening
+```
+
+The capability must produce advisory liveness/progress plans, not confirmed findings. A plan becomes a finding only after deterministic replay, fuzzing, symbolic execution, local fixture validation, or human review confirms that legitimate progress can be blocked or made economically impractical.
+
+Primary objectives:
+
+1. Identify externally growable resources: arrays, queues, mappings with enumerable indexes, pending payments, claim sets, proposal lists, keeper work queues, withdrawal queues, batch settlement sets, and per-user state that affects global loops.
+2. Identify progress-critical functions: withdraw, claim, refund, settle, execute, liquidate, process, finalize, burn, redeem, bridge relay, keeper upkeep, and emergency recovery.
+3. Infer liveness properties such as bounded batch progress, per-user withdrawal availability, retryability after failed callbacks, keeper substitution, and no single-recipient blocking.
+4. Generate validation obligations for fuzzing, symbolic execution, and local fixtures that try to grow resources, force callback reverts, under-provision gas, or skip privileged keepers.
+5. Downgrade unconfirmed plans and preserve false-positive controls for intentionally bounded, paginated, pull-based, or admin-recoverable designs.
+
+## Design/Contract
+
+Introduce a provider-neutral data contract before implementation:
+
+```python
+ResourceLivenessGriefingPlan = {
+    "id": "string",
+    "objective": "string",
+    "surface": {
+        "resource": "string",
+        "resource_kind": "array|queue|mapping_index|pending_payment|keeper_task|withdrawal_queue|proposal_queue|external_callback|unknown",
+        "growth_sources": ["function"],
+        "progress_functions": ["function"],
+        "source_anchors": ["file:line"],
+    },
+    "liveness_hypothesis": {
+        "category": "unbounded_loop|state_bloat|push_payment_blocking|withdrawal_queue_blocking|keeper_blocking|revert_griefing|insufficient_gas_griefing|batch_progress_failure|rate_limit_gap|fallback_absence",
+        "attacker_action": "string",
+        "honest_user_goal": "string",
+        "blocked_progress": "string",
+        "preconditions": ["string"],
+        "negative_checks": ["string"],
+    },
+    "progress_oracle": {
+        "property": "string",
+        "bounded_work_claim": "string",
+        "expected_revert_or_failure": "string",
+        "success_condition": "string",
+    },
+    "execution_plan": {
+        "recommended_tools": ["foundry", "echidna", "halmos", "local_fixture", "human_review"],
+        "sequence": ["call"],
+        "actors": ["attacker", "honest_user", "keeper", "admin"],
+        "inputs_to_mutate": ["string"],
+        "resource_growth_budget": "string",
+        "gas_budget_hint": "string",
+    },
+    "promotion": {
+        "state": "hypothesis|test_generated|counterexample|replayed|rejected",
+        "evidence": ["string"],
+        "blockers": ["string"],
+    },
+    "metadata": {
+        "capability": "resource_liveness_griefing_hardening",
+        "schema_version": "1",
+    },
+}
+```
+
+The capability should compose existing MIESC pieces:
+
+- Classic DoS detectors remain first-pass local signals for loops, push payments, and failed calls.
+- `SequenceOraclePlan` supplies call ordering for growth then progress attempts.
+- `SnapshotFuzzingPlan` supplies reusable bloated-state seeds and waypoints.
+- `SemanticGraphGate` supplies state/resource/function anchors.
+- `SlithIR SSA + Interprocedural State/Taint Summary` can identify growth provenance and attacker-controlled sizes.
+- `External Call Returndata Hardening` remains the sub-surface for unbounded returndata and revert-data griefing.
+- `InvariantValidator`, Echidna, Foundry, and Halmos can validate progress properties and counterexamples.
+- False-positive filtering must downgrade plans when pagination, pull payments, retry paths, keeper substitution, or emergency recovery are actually present.
+
+## Prompt Requirements
+
+Prompt and parser design must refer to an **interchangeable security reasoning agent**. No schema, parser, prompt, or test may bind the capability to a specific vendor, hosted endpoint, product family, or model.
+
+The reasoning agent must:
+
+- Separate observed resource growth from inferred liveness risk.
+- Anchor each resource and progress function to source lines.
+- Return at least one negative check for every hypothesis.
+- Prefer executable progress oracles over narrative severity.
+- Avoid confirmed-finding language until validation confirms blocked progress.
+- Support deterministic local fallback based on loops, storage growth, external calls, and function naming.
+
+## False-Positive Controls
+
+The capability must avoid noisy DoS findings:
+
+- Dynamic loops are not findings when bounded by a small constant, pagination, or caller-owned slices.
+- Push-style external calls are not findings when each recipient failure is isolated and retryable.
+- Keeper-only progress is not a finding when any keeper can act, users can self-service, or emergency fallback exists.
+- Withdrawal queues are not findings when queue growth is bounded and progress is amortized across calls.
+- Gas-heavy operations are not findings without attacker-controlled growth or a progress-critical path.
+- A failed external call is not a liveness finding if state remains consistent and retryable.
+- Provider output must be bounded and parser-validated before integration.
+
+Promotion rules:
+
+- `hypothesis`: resource/progress surface and liveness risk only.
+- `test_generated`: a progress oracle or harness exists but has not failed.
+- `counterexample`: fuzzing or symbolic execution demonstrates blocked progress.
+- `replayed`: deterministic local or fork replay demonstrates stuck funds, blocked settlement, or unavailable progress.
+- `rejected`: pagination, pull pattern, retry path, fallback actor, or bounded work disproves the risk.
+
+## Non-Goals
+
+- No replacement for existing DoS detectors.
+- No canonical benchmark update from this SDD alone.
+- No profitability requirement; griefing can be impact-driven without direct profit.
+- No remote-chain dependency in the first implementation.
+- No confirmed vulnerability when only a large loop exists.
+- No provider-specific dependency.
+
+## Integration Plan
+
+Phase 0 is this SDD. Future work should land in small, testable steps:
+
+1. Add provider-neutral schema contracts and parser tests.
+2. Add local resource-growth extraction for arrays, queues, mappings, and pending payment structures.
+3. Add progress-function classifier for withdraw/claim/refund/settle/execute/liquidate/process/finalize/upkeep paths.
+4. Add local liveness hypothesis generator for unbounded loops, push-payment blocking, keeper blocking, insufficient gas griefing, state bloat, and batch progress failure.
+5. Generate progress oracles for Foundry/Echidna/Halmos/local fixtures.
+6. Add fixtures with safe and unsafe variants for each liveness family.
+7. Run only non-canonical probes until benchmark promotion is explicitly approved.
+
+## 50-Activity Parallelization Map
+
+These activities can run across five lanes with disjoint file ownership.
+
+1. Inventory current DoS detector outputs.
+2. Inventory cross-function DoS heuristic fields.
+3. Inventory SmartBugs DoS fixtures and labels.
+4. Inventory benchmark false negatives in `denial_of_service`.
+5. Inventory existing sequence/snapshot plan inputs.
+6. Define `ResourceSurface` schema.
+7. Define `GrowthSource` schema.
+8. Define `ProgressFunction` schema.
+9. Define `LivenessHypothesis` schema.
+10. Define `ResourceLivenessGriefingPlan` schema.
+11. Add parser for canonical output key.
+12. Add parser aliases for DoS/liveness plans.
+13. Add bounded text/list sanitization.
+14. Add no-provider-binding regression tests.
+15. Export public facade symbols.
+16. Detect arrays that grow through public/external calls.
+17. Detect queues with head/tail progress.
+18. Detect mappings with enumerable indexes.
+19. Detect pending payment structures.
+20. Detect proposal/settlement/keeper task queues.
+21. Detect progress-critical function names.
+22. Detect external calls inside batch loops.
+23. Detect push-payment blocking patterns.
+24. Detect withdrawal queue blocking patterns.
+25. Detect keeper-only progress assumptions.
+26. Detect insufficient-gas griefing candidates.
+27. Detect state-bloat surfaces.
+28. Detect missing pagination or batch size caps.
+29. Detect missing retry paths after failed callbacks.
+30. Detect missing emergency recovery paths.
+31. Add negative checks for bounded loops.
+32. Add negative checks for pull-payment design.
+33. Add negative checks for retryable failures.
+34. Add negative checks for keeper substitution.
+35. Add negative checks for user self-service progress.
+36. Generate Foundry progress property metadata.
+37. Generate Echidna liveness-like property metadata.
+38. Generate Halmos assertion metadata.
+39. Generate local fixture obligations.
+40. Bridge plans to sequence-oracle synthesis.
+41. Bridge bloated-state seeds to snapshot fuzzing.
+42. Bridge growth provenance to semantic graph gates.
+43. Bridge attacker-controlled sizes to SSA/taint summaries.
+44. Add fixture: unbounded recipient loop blocks withdrawal.
+45. Add fixture: safe paginated recipient processing.
+46. Add fixture: reverting recipient blocks push payment.
+47. Add fixture: safe pull payment retry path.
+48. Add fixture: keeper-only blocked settlement.
+49. Add fixture: safe self-service fallback settlement.
+50. Add runbook notes for comparing progress-oracle plans with benchmark findings.
+
+Parallel lanes:
+
+- Lane A: schemas, parser, exports, and provider-neutral tests.
+- Lane B: resource/growth/progress extraction.
+- Lane C: liveness hypothesis generation and negative checks.
+- Lane D: progress-oracle generation and tool metadata bridges.
+- Lane E: fixtures, non-canonical evidence, benchmark comparison, and runbook notes.
+
+## Validation
+
+For this SDD:
+
+```bash
+test -s docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md
+rg -n "interchangeable security reasoning agent|provider-neutral|50-Activity" docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md
+git diff --check -- docs/SDD_RESOURCE_LIVENESS_GRIEFING_HARDENING_20260811.md
+```
+
+Provider/model-name checks should run against the document content during review and should return no requirement binding the capability to one provider.
+
+For future implementation:
+
+- Unit tests for resource and progress-function extraction.
+- Parser tests for bounded provider-neutral output.
+- Fixture tests for unsafe and safe variants of each liveness family.
+- Integration tests proving local DoS warnings stay advisory without a blocked-progress oracle.
+- Non-canonical benchmark probes before any claimed uplift.
+
+## References
+
+- OWASP SCWE-059: Insufficient Gas Griefing. https://scs.owasp.org/SCWE/SCSVS-DEFI/SCWE-059/
+- OWASP Smart Contract Security Testing Guide: Denial of Service overview. https://scs.owasp.org/SCSTG/tests/SCSVS-BLOCK/overview/
+- SMARTIAN: Enhancing Smart Contract Fuzzing with Static and Dynamic Data-Flow Analyses, ASE 2021. https://conf.researchr.org/details/ase-2021/ase-2021-papers/66/SMARTIAN-Enhancing-Smart-Contract-Fuzzing-with-Static-and-Dynamic-Data-Flow-Analyse
+- Echidna smart contract fuzzer. https://github.com/crytic/echidna
+- Local reference: `docs/SDD_SEQUENCE_ORACLE_DETECTION_20260709.md`
+- Local reference: `docs/SDD_SNAPSHOT_FUZZING_GUIDANCE_20260709.md`
+- Local reference: `docs/SDD_EXTERNAL_CALL_RETURNDATA_HARDENING_20260712.md`
+- Local evidence: `benchmarks/results/v6.0.0_benchmark_report_20260811.md`

--- a/docs/SDD_YUL_ASSEMBLY_MEMORY_SAFETY_HARDENING_20260811.md
+++ b/docs/SDD_YUL_ASSEMBLY_MEMORY_SAFETY_HARDENING_20260811.md
@@ -1,0 +1,256 @@
+# SDD: Yul/Inline-Assembly Memory and Storage Safety Hardening
+
+Date: 2026-08-11
+Owner/Lane: Codex
+Status: Proposed SDD, not implemented, no benchmark claim
+
+## Signal
+
+MIESC already records broad Solidity coverage: static analyzers, symbolic/formal tools, fuzzing adapters, semantic graph gates, sequence/snapshot plans, interprocedural summary planning, delegatecall storage aliasing, transient storage, external-call returndata, and local/provider-neutral reasoning contracts. Existing assembly coverage is mostly shallow: tools can flag `assembly` usage, direct `sstore`, `delegatecall`, `calldatacopy`, or low-level call patterns, but MIESC does not yet create a structured model of what an inline assembly block does to memory, calldata, storage, returndata, stack-derived pointers, or Solidity reference variables.
+
+That gap matters because inline assembly deliberately crosses the boundary where Solidity's normal safety and optimizer assumptions are weaker. Solidity's documentation warns that memory-using inline assembly has to respect the Solidity memory model, that `memory-safe` annotations are the developer's responsibility, and that violating those assumptions can lead to undefined behavior that is hard to discover through testing. OWASP SCWE-039 also treats insecure inline assembly as a smart-contract weakness, including incorrect type conversions, unsafe low-level operations, and loss of funds or data. Slither currently exposes an `assembly` detector, but it is an informational warning rather than a semantic analysis of assembly effects.
+
+The technique to add is **Yul/Inline-Assembly Memory and Storage Safety Hardening**: parse inline assembly fragments into bounded effect summaries, classify memory/storage/calldata/returndata hazards, and emit provider-neutral validation obligations that can feed semantic graph gating, SSA/interprocedural summaries, fuzzing, symbolic checks, and PoC scaffolding.
+
+## Spec/Goal
+
+Add a future capability named:
+
+```text
+yul_assembly_memory_safety_hardening
+```
+
+Expected output key:
+
+```text
+yul_assembly_safety_plans
+```
+
+Suggested aliases:
+
+```text
+assembly_memory_safety
+yul_effect_summary
+inline_assembly_hardening
+```
+
+The capability must produce advisory analysis and validation plans. A raw `assembly` block is not a vulnerability by itself; promotion requires a concrete unsafe effect, source anchor, reachable function context, and either deterministic evidence or a clearly reviewable validation obligation.
+
+Primary objectives:
+
+1. Extract inline assembly/Yul blocks with source anchors and enclosing Solidity function context.
+2. Summarize reads/writes to memory, storage, calldata, returndata, free-memory pointer, zero slot, and Solidity reference variables.
+3. Classify hazards such as unsafe `memory-safe` annotation, scratch-space overflow, free-memory pointer corruption, zero-slot corruption, unbounded `returndatacopy`, arbitrary `sstore`, unchecked downcast, manual calldata decoding without bounds, custom dispatch ambiguity, and low-level call/delegatecall side effects.
+4. Generate validation obligations for fuzzing, symbolic execution, local fixture tests, or human review.
+5. Preserve provider-neutral contracts so a deterministic local analyzer, local model, or hosted reasoning provider can be swapped without changing downstream interfaces.
+
+## Design/Contract
+
+Introduce a provider-neutral data contract before implementation:
+
+```python
+YulAssemblySafetyPlan = {
+    "id": "string",
+    "objective": "string",
+    "source_anchor": "file:line",
+    "enclosing_function": "string",
+    "assembly_summary": {
+        "dialect": "evm|yul|unknown",
+        "is_memory_safe_annotated": "bool",
+        "instructions": ["string"],
+        "memory_reads": ["string"],
+        "memory_writes": ["string"],
+        "storage_reads": ["string"],
+        "storage_writes": ["string"],
+        "calldata_reads": ["string"],
+        "returndata_reads": ["string"],
+        "external_effects": ["call|delegatecall|staticcall|create|create2|selfdestruct"],
+        "solidity_variable_bindings": ["string"],
+    },
+    "hazards": [
+        {
+            "category": "unsafe_memory_safe_annotation|scratch_space_overflow|free_memory_pointer_corruption|zero_slot_corruption|arbitrary_storage_write|manual_calldata_decode_without_bounds|unchecked_downcast|unbounded_returndata_copy|custom_dispatch_ambiguity|low_level_call_side_effect",
+            "evidence": ["string"],
+            "preconditions": ["string"],
+            "negative_checks": ["string"],
+            "confidence": "low|medium|high",
+        }
+    ],
+    "validation_obligations": [
+        {
+            "tool": "foundry|echidna|halmos|local_fixture|human_review",
+            "property": "string",
+            "expected_failure_or_revert": "string",
+            "inputs_to_mutate": ["string"],
+            "budget_hint": "string",
+        }
+    ],
+    "promotion": {
+        "state": "hypothesis|test_generated|counterexample|replayed|rejected",
+        "evidence": ["string"],
+        "blockers": ["string"],
+    },
+    "metadata": {
+        "capability": "yul_assembly_memory_safety_hardening",
+        "schema_version": "1",
+    },
+}
+```
+
+The capability should compose existing MIESC pieces:
+
+- Slither/Aderyn/Solhint can remain first-pass signal sources for `assembly`, `low-level-calls`, and related warnings.
+- `SlithIR SSA + Interprocedural State/Taint Summary` can consume storage, calldata, and call-effect summaries.
+- `SemanticGraphGate` can prioritize functions where assembly writes privileged state or forwards untrusted calldata.
+- `External Call Returndata Hardening` can consume unbounded or unsafe returndata-copy summaries.
+- `Delegatecall Storage Aliasing` can consume assembly `delegatecall` and `sstore` effects.
+- `InvariantValidator`, Foundry, Echidna, and Halmos can validate generated properties.
+- False-positive filtering must downgrade benign, bounded, compiler-supported, or unreachable assembly fragments.
+
+## Prompt Requirements
+
+Prompt and parser design must refer to an **interchangeable security reasoning agent**. No prompt, schema, parser, test, or SDD requirement may require one vendor, product, endpoint, or model family.
+
+The reasoning agent must:
+
+- Anchor every assembly effect to a source block and enclosing Solidity function.
+- Separate observed instructions from inferred hazard hypotheses.
+- Include negative checks for known-safe idioms and compiler-supported patterns.
+- Treat `memory-safe` annotations as claims to validate, not proof.
+- Avoid confirmed-finding language until execution, symbolic validation, or human review confirms impact.
+- Support deterministic local fallback based on parsed opcodes and bounded heuristics.
+
+## False-Positive Controls
+
+The capability must avoid noisy "assembly is bad" findings:
+
+- A block that only reads immutable values or uses bounded memory scratch space remains advisory unless a hazard is identified.
+- `memory-safe` annotated blocks are not trusted blindly, but they are not findings without a violated memory-model rule.
+- Direct `sstore` is not automatically exploitable; it requires reachability, attacker influence, or sensitive slot impact.
+- Manual calldata decoding is not a finding if length checks dominate every load.
+- Returndata copying is not a finding when bounded by the free-memory pointer and restored memory invariants.
+- Assembly inside trusted libraries should retain library/version provenance and safe idiom notes.
+- Provider output must be parser-bounded before any integration.
+
+Promotion rules:
+
+- `hypothesis`: assembly effect and hazard category only.
+- `test_generated`: a check exists but has not produced a failing execution.
+- `counterexample`: fuzzing or symbolic execution violates the property.
+- `replayed`: deterministic local or fork replay demonstrates impact.
+- `rejected`: negative checks prove the fragment is bounded, unreachable, or benign.
+
+## Non-Goals
+
+- No rewrite of the Solidity parser.
+- No new EVM decompiler.
+- No canonical benchmark update from this SDD alone.
+- No blanket ban on inline assembly.
+- No provider-specific reasoning dependency.
+- No confirmed vulnerability when only an informational assembly warning exists.
+
+## Integration Plan
+
+Phase 0 is this SDD. Future work should land in small, testable steps:
+
+1. Add schema contracts and parser tests under the provider-neutral agentic contract layer.
+2. Add deterministic extraction of inline assembly blocks with source anchors.
+3. Add a minimal Yul opcode/effect tokenizer for memory, storage, calldata, returndata, and call instructions.
+4. Add local hazard classifiers for memory-safe annotation misuse, unbounded copies, arbitrary storage writes, and manual calldata decoding.
+5. Bridge effect summaries into semantic graph, SSA/interprocedural summary, returndata hardening, and delegatecall aliasing surfaces.
+6. Generate validation obligations for Foundry, Echidna, Halmos, local fixtures, and human review.
+7. Keep evaluation non-canonical until a controlled baseline run is explicitly approved.
+
+## 50-Activity Parallelization Map
+
+These activities can run across five lanes with disjoint file ownership.
+
+1. Inventory existing assembly-related detectors.
+2. Inventory existing low-level call summaries.
+3. Inventory existing returndata hardening fields.
+4. Inventory delegatecall storage aliasing contract fields.
+5. Inventory SlithIR/Yul/opcode data available from tool outputs.
+6. Define `YulAssemblyBlock` schema.
+7. Define `YulMemoryEffect` schema.
+8. Define `YulStorageEffect` schema.
+9. Define `YulCalldataEffect` schema.
+10. Define `YulAssemblySafetyPlan` schema.
+11. Add strict parser for canonical output key.
+12. Add aliases for assembly safety plans.
+13. Add bounded list/text sanitization.
+14. Add no-provider-binding regression tests.
+15. Export public facade symbols.
+16. Implement assembly block extraction.
+17. Preserve source anchors and enclosing function names.
+18. Tokenize `mload`, `mstore`, and `mstore8`.
+19. Tokenize `sload` and `sstore`.
+20. Tokenize `calldataload`, `calldatacopy`, and calldata offset/length usage.
+21. Tokenize `returndatasize` and `returndatacopy`.
+22. Tokenize `call`, `delegatecall`, and `staticcall`.
+23. Tokenize `create`, `create2`, and `selfdestruct`.
+24. Detect `memory-safe` annotations.
+25. Detect deprecated memory-safe comments.
+26. Classify scratch-space overflow hazards.
+27. Classify free-memory pointer corruption hazards.
+28. Classify zero-slot corruption hazards.
+29. Classify arbitrary storage write hazards.
+30. Classify unchecked downcast hazards.
+31. Classify manual calldata decode without bounds.
+32. Classify unbounded returndata copy.
+33. Classify custom dispatcher ambiguity.
+34. Classify low-level call side effects.
+35. Add negative checks for bounded scratch-space idioms.
+36. Add negative checks for restored free-memory pointer.
+37. Add negative checks for dominated calldata bounds.
+38. Add negative checks for fixed storage-slot constants.
+39. Bridge summaries into semantic graph gates.
+40. Bridge summaries into interprocedural state/taint summaries.
+41. Bridge returndata hazards into external-call returndata plans.
+42. Bridge delegatecall hazards into storage aliasing plans.
+43. Generate Foundry property metadata.
+44. Generate Echidna property metadata.
+45. Generate Halmos assertion metadata.
+46. Add vulnerable fixture for unsafe downcast in assembly.
+47. Add safe fixture for bounded downcast.
+48. Add vulnerable fixture for unbounded returndata copy.
+49. Add safe fixture for memory-safe returndata copy.
+50. Add runbook notes for reviewing assembly plans against confirmed findings.
+
+Parallel lanes:
+
+- Lane A: schemas, parser, exports, and provider-neutral tests.
+- Lane B: deterministic block extraction and opcode/effect tokenizer.
+- Lane C: hazard classifiers and negative checks.
+- Lane D: bridges into semantic graph, SSA summaries, delegatecall, and returndata plans.
+- Lane E: fixtures, validation obligations, non-canonical evidence, and runbook notes.
+
+## Validation
+
+For this SDD:
+
+```bash
+test -s docs/SDD_YUL_ASSEMBLY_MEMORY_SAFETY_HARDENING_20260811.md
+rg -n "interchangeable security reasoning agent|provider-neutral|50-Activity" docs/SDD_YUL_ASSEMBLY_MEMORY_SAFETY_HARDENING_20260811.md
+git diff --check -- docs/SDD_YUL_ASSEMBLY_MEMORY_SAFETY_HARDENING_20260811.md
+```
+
+Provider/model-name checks should run against the document content during review and should return no requirement binding the capability to one provider.
+
+For future implementation:
+
+- Unit tests for block extraction and source anchors.
+- Parser tests for bounded provider-neutral output.
+- Fixture tests for unsafe and safe variants of each hazard family.
+- Integration tests proving raw assembly warnings stay advisory.
+- Non-canonical benchmark probes before any claimed uplift.
+
+## References
+
+- Solidity documentation: Inline Assembly and memory safety. https://docs.soliditylang.org/en/latest/assembly.html
+- Solidity documentation: Yul. https://docs.soliditylang.org/en/latest/yul.html
+- OWASP SCWE-039: Insecure Use of Inline Assembly. https://scs.owasp.org/SCWE/SCSVS-CODE/SCWE-039/
+- Slither detector documentation: `assembly` and low-level call detectors. https://github.com/crytic/slither/wiki/Detector-Documentation
+- A Study of Inline Assembly in Solidity Smart Contracts, OOPSLA 2022. https://doi.org/10.1145/3563328
+- Local reference: `docs/SDD_DELEGATECALL_STORAGE_ALIASING_20260711.md`
+- Local reference: `docs/SDD_EXTERNAL_CALL_RETURNDATA_HARDENING_20260712.md`
+- Local reference: `docs/SDD_TRANSIENT_STORAGE_DETECTION_20260709.md`


### PR DESCRIPTION
## Summary
- add SmartBugs v6.0.0 benchmark report and additive FP-filter evidence
- version DeFiHackLabs raw arena evidence referenced by the v6 report
- add provider-neutral SDDs for Yul assembly memory safety, resource/liveness griefing, privileged governance lifecycle, and lending solvency/liquidation
- merge latest origin/main so PoC scaffold and acceptance-provider changes are included

## Validation
- python3 -m pytest tests/test_poc_check.py tests/test_counterexample_poc.py tests/test_acceptance_patterns.py -q
- git diff --check HEAD~1..HEAD

## Notes
- canonical benchmark artifacts were not overwritten during the SDD checkpoints
- one local untracked legacy script remains outside the PR: benchmarks/smartbugs_fp_filter_effect_20260710.py