### PR TITLE
Fix baseline fingerprint collisions

### DIFF
--- a/miesc/core/baseline.py
+++ b/miesc/core/baseline.py
@@ -28,7 +28,11 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Union
 
 # Version of the on-disk baseline schema. Bump on breaking format changes.
-BASELINE_FORMAT_VERSION = "1.0"
+# 1.1: fingerprint now includes the function/symbol and strips line references from
+#      the message, so co-located findings no longer collide (fail-open) and a
+#      message that embeds its line number stays stable under line shifts
+#      (fail-closed). Baselines written by 1.0 must be regenerated.
+BASELINE_FORMAT_VERSION = "1.1"
 
 # Default filename written by ``generate_baseline`` / the ``baseline generate``
 # command and consumed by the ``--baseline`` CLI flags.
@@ -40,6 +44,18 @@ FindingLike = Union[Mapping[str, Any], Any]
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
+# Line/column references embedded in tool messages. Stripped before hashing so the
+# fingerprint stays stable when unrelated edits shift a finding's line number.
+# Conservative: only matches explicit line/col markers, never bare numbers (which
+# may be a legitimate part of the message, e.g. an SWC id or a numeric constant).
+_LINE_REF_RE = re.compile(
+    r"(?ix)"
+    r"\b(?:line|ln|row|col|column|position|offset)s?\s*[:#=]?\s*\d+(?:\s*[:,-]\s*\d+)?"
+    r"|(?<![\w.])[:@]\d+(?::\d+)?\b"
+    r"|\#\d+\b"
+    r"|\bL\d+\b"
+)
+
 
 @dataclass(frozen=True)
 class BaselineEntry:
@@ -48,6 +64,7 @@ class BaselineEntry:
     fingerprint: str
     rule_id: str
     file: str
+    symbol: str
     message_hash: str
     severity: str
 
@@ -55,6 +72,7 @@ class BaselineEntry:
         return {
             "rule_id": self.rule_id,
             "file": self.file,
+            "symbol": self.symbol,
             "message_hash": self.message_hash,
             "severity": self.severity,
         }
@@ -77,7 +95,7 @@ class Baseline:
         """Return a JSON-serializable, deterministically-ordered mapping."""
         return {
             "version": self.version,
-            "fingerprint_algorithm": "sha256-content-16",
+            "fingerprint_algorithm": "sha256-content-symbol-16",
             "count": len(self.entries),
             "fingerprints": {fp: self.entries[fp].to_dict() for fp in sorted(self.entries)},
         }
@@ -101,6 +119,7 @@ class Baseline:
                 fingerprint=fp,
                 rule_id=str(meta.get("rule_id", "")),
                 file=str(meta.get("file", "")),
+                symbol=str(meta.get("symbol", "")),
                 message_hash=str(meta.get("message_hash", "")),
                 severity=str(meta.get("severity", "")),
             )
@@ -138,6 +157,22 @@ def _extract_file(finding: FindingLike) -> str:
     return _normalize_path(_get(finding, "file", "file_path", "filename"))
 
 
+def _extract_symbol(finding: FindingLike) -> str:
+    """Resolve the narrowest function/symbol scope available for a finding."""
+    if isinstance(finding, Mapping):
+        loc = finding.get("location")
+        if isinstance(loc, Mapping):
+            symbol = (
+                loc.get("function")
+                or loc.get("function_name")
+                or loc.get("symbol")
+                or loc.get("contract")
+            )
+            if symbol:
+                return _normalize_symbol(str(symbol))
+    return _normalize_symbol(_get(finding, "function", "function_name", "symbol", "contract"))
+
+
 def _normalize_path(path: str) -> str:
     """Normalize a file path for stable cross-run / cross-machine matching.
 
@@ -159,9 +194,21 @@ def _normalize_path(path: str) -> str:
     return prefix + "/".join(parts)
 
 
+def _normalize_symbol(symbol: str) -> str:
+    """Normalize function/symbol scope without erasing meaningful overload text."""
+    return _WHITESPACE_RE.sub(" ", symbol).strip()
+
+
 def _normalize_message(message: str) -> str:
-    """Collapse whitespace so cosmetic reformatting does not change the hash."""
-    return _WHITESPACE_RE.sub(" ", message).strip()
+    """Canonicalize a finding message for hashing.
+
+    Collapses whitespace AND strips embedded line/column references, so a message
+    like ``"Reentrancy in withdraw() (line 42)"`` hashes the same after code above
+    it shifts the line number — otherwise a baselined finding would be re-flagged as
+    new on the next run (fail-closed).
+    """
+    stripped = _LINE_REF_RE.sub("", message)
+    return _WHITESPACE_RE.sub(" ", stripped).strip()
 
 
 def _message_hash(message: str) -> str:
@@ -172,11 +219,13 @@ def normalize_finding(finding: FindingLike) -> Dict[str, str]:
     """Reduce a heterogeneous finding to the canonical fields we fingerprint."""
     rule_id = _get(finding, "type", "rule_id", "check", "title", default="unknown")
     file = _extract_file(finding)
+    symbol = _extract_symbol(finding)
     message = _get(finding, "message", "description", "title", default="")
     severity = _get(finding, "severity", default="").lower()
     return {
         "rule_id": rule_id,
         "file": file,
+        "symbol": symbol,
         "message": message,
         "message_hash": _message_hash(message),
         "severity": severity,
@@ -186,7 +235,7 @@ def normalize_finding(finding: FindingLike) -> Dict[str, str]:
 def fingerprint(finding: FindingLike) -> str:
     """Return the content-based fingerprint for a finding (line-shift stable)."""
     norm = normalize_finding(finding)
-    content = f"{norm['rule_id']}|{norm['file']}|{norm['message_hash']}"
+    content = f"{norm['rule_id']}|{norm['file']}|{norm['symbol']}|{norm['message_hash']}"
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
 
 
@@ -196,6 +245,7 @@ def _to_entry(finding: FindingLike) -> BaselineEntry:
         fingerprint=fingerprint(finding),
         rule_id=norm["rule_id"],
         file=norm["file"],
+        symbol=norm["symbol"],
         message_hash=norm["message_hash"],
         severity=norm["severity"],
     )

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -30,13 +30,20 @@ from miesc.core.baseline import (
 
 
 def _finding(
-    rule="reentrancy", file="contracts/Bank.sol", line=15, message="Reentrancy in withdraw()"
+    rule="reentrancy",
+    file="contracts/Bank.sol",
+    line=15,
+    message="Reentrancy in withdraw()",
+    function="",
 ):
+    location = {"file": file, "line": line}
+    if function:
+        location["function"] = function
     return {
         "type": rule,
         "severity": "high",
         "message": message,
-        "location": {"file": file, "line": line},
+        "location": location,
         "tool": "slither",
     }
 
@@ -73,6 +80,16 @@ class TestFingerprint:
         b = _finding(message="Reentrancy in withdraw()")
         assert fingerprint(a) == fingerprint(b)
 
+    def test_fingerprint_ignores_embedded_message_line_reference(self):
+        a = _finding(message="Reentrancy in withdraw() line 42")
+        b = _finding(message="Reentrancy in withdraw() line 137")
+        assert fingerprint(a) == fingerprint(b)
+
+    def test_fingerprint_changes_with_function_symbol(self):
+        a = _finding(message="Unchecked external call", function="withdraw")
+        b = _finding(message="Unchecked external call", function="claim")
+        assert fingerprint(a) != fingerprint(b)
+
     def test_normalized_path_equivalence(self):
         """./contracts/Bank.sol and contracts/Bank.sol match."""
         a = _finding(file="./contracts/Bank.sol")
@@ -91,9 +108,10 @@ class TestFingerprint:
         assert fingerprint(nested) == fingerprint(flat)
 
     def test_normalize_finding_fields(self):
-        norm = normalize_finding(_finding(rule="reentrancy", file="a/b.sol"))
+        norm = normalize_finding(_finding(rule="reentrancy", file="a/b.sol", function="withdraw"))
         assert norm["rule_id"] == "reentrancy"
         assert norm["file"] == "a/b.sol"
+        assert norm["symbol"] == "withdraw"
         assert norm["severity"] == "high"
         assert len(norm["message_hash"]) == 16
 

--- a/tests/test_baseline_cli.py
+++ b/tests/test_baseline_cli.py
@@ -24,7 +24,7 @@ from miesc.cli.commands.baseline import (
     baseline,
     load_findings_from_results,
 )
-from miesc.core.baseline import generate_baseline
+from miesc.core.baseline import diff_against_baseline, fingerprint, generate_baseline
 
 # =============================================================================
 # Helpers
@@ -32,13 +32,17 @@ from miesc.core.baseline import generate_baseline
 
 
 def _finding(
-    rule="reentrancy", file="contracts/Bank.sol", line=15, message="Reentrancy in withdraw()"
+    rule="reentrancy",
+    file="contracts/Bank.sol",
+    line=15,
+    message="Reentrancy in withdraw()",
+    function="withdraw",
 ):
     return {
         "type": rule,
         "severity": "high",
         "message": message,
-        "location": {"file": file, "line": line},
+        "location": {"file": file, "line": line, "function": function},
         "tool": "slither",
     }
 
@@ -116,6 +120,30 @@ class TestGenerateCommand:
         assert result.exit_code == 0
         assert str(out) in result.output
 
+    def test_generate_records_1_1_symbol_scoped_fingerprints(self, tmp_path):
+        baseline_obj = generate_baseline(
+            [
+                _finding(message="Reentrancy risk", function="withdraw"),
+                _finding(message="Reentrancy risk", function="claim"),
+            ]
+        )
+
+        data = baseline_obj.to_dict()
+        assert data["version"] == "1.1"
+        assert data["count"] == 2
+        assert {entry["symbol"] for entry in data["fingerprints"].values()} == {
+            "claim",
+            "withdraw",
+        }
+
+    def test_fingerprint_ignores_embedded_line_references_but_keeps_symbol_scope(self):
+        old_line = _finding(message="Reentrancy in withdraw() (line 42)", function="withdraw")
+        new_line = _finding(message="Reentrancy in withdraw() (line 200)", function="withdraw")
+        other_function = _finding(message="Reentrancy in withdraw() (line 42)", function="claim")
+
+        assert fingerprint(old_line) == fingerprint(new_line)
+        assert fingerprint(old_line) != fingerprint(other_function)
+
 
 # =============================================================================
 # baseline diff
@@ -146,6 +174,19 @@ class TestDiffCommand:
         result = runner.invoke(baseline, ["diff", str(results), "--baseline", str(base)])
         assert "New:   0" in result.output
         assert "Known: 1" in result.output
+
+    def test_diff_embedded_message_line_shift_stays_known(self, tmp_path):
+        base = generate_baseline(
+            [_finding(message="Reentrancy in withdraw() at line 15", function="withdraw")]
+        )
+
+        result = diff_against_baseline(
+            [_finding(message="Reentrancy in withdraw() at line 200", function="withdraw")],
+            base,
+        )
+
+        assert result["new"] == []
+        assert len(result["known"]) == 1
 
     def test_fail_on_new_exits_1_when_new(self, tmp_path):
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- Bump baseline format to 1.1 and include function/symbol scope in finding fingerprints.
- Strip explicit line/column references from finding messages before hashing, preserving line-shift stability.
- Add core and CLI regression tests for symbol-scoped fingerprints and embedded line-reference shifts.

## Validation
- python3 -m pytest tests/test_baseline.py tests/test_baseline_cli.py -q
- python3 -m ruff check miesc/core/baseline.py tests/test_baseline.py tests/test_baseline_cli.py
- python3 -m py_compile miesc/core/baseline.py tests/test_baseline.py tests/test_baseline_cli.py
- git diff --check