### PR TITLE
Feat: wire access-control detector into quick scanner

### DIFF
--- a/miesc/core/quick_scanner.py
+++ b/miesc/core/quick_scanner.py
@@ -99,6 +99,19 @@ class QuickScanner:
             except Exception as e:
                 logger.error(f"{tool} failed: {e}")
 
+        try:
+            local_findings = self._run_local_access_control(contract_path)
+            if local_findings:
+                results["tools_run"].append("access-control-semantic-detector")
+                results["findings"].extend(local_findings)
+                if verbose:
+                    logger.info(
+                        "access-control-semantic-detector: %d findings",
+                        len(local_findings),
+                    )
+        except Exception as e:
+            logger.error(f"access-control-semantic-detector failed: {e}")
+
         # Calculate summary
         results["execution_time"] = (datetime.now() - start_time).total_seconds()
         results["summary"] = self._calculate_summary(results["findings"])
@@ -114,6 +127,20 @@ class QuickScanner:
         elif tool == "solhint":
             return self._run_solhint(contract_path)
         return []
+
+    def _run_local_access_control(self, contract_path: str) -> List[Dict]:
+        """Run the built-in semantic access-control detector."""
+        from miesc.ml.classic_patterns import AccessControlSemanticDetector
+
+        source = Path(contract_path).read_text(encoding="utf-8")
+        detector = AccessControlSemanticDetector()
+        findings = detector.to_findings(detector.analyze(source))
+        for finding in findings:
+            finding["tool"] = "access-control-semantic-detector"
+            finding["severity"] = self._normalize_severity(finding.get("severity", ""))
+            location = finding.setdefault("location", {})
+            location["file"] = contract_path
+        return findings
 
     def _run_slither(self, contract_path: str) -> List[Dict]:
         """Run Slither static analyzer."""

--- a/tests/test_quick_scanner_behavior.py
+++ b/tests/test_quick_scanner_behavior.py
@@ -154,6 +154,30 @@ class TestRunSolhint:
         assert findings[0]["line"] == 3
 
 
+class TestRunLocalAccessControl:
+    def test_detects_unprotected_privileged_function(self, scanner_all_available, tmp_path):
+        contract = tmp_path / "Vault.sol"
+        contract.write_text(
+            "pragma solidity ^0.8.0;\n"
+            "contract Vault {\n"
+            "  address public owner;\n"
+            "  function setOwner(address next) external {\n"
+            "    owner = next;\n"
+            "  }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        findings = scanner_all_available._run_local_access_control(str(contract))
+
+        assert any(f["type"] == "missing-access-control" for f in findings)
+        finding = next(f for f in findings if f["type"] == "missing-access-control")
+        assert finding["tool"] == "access-control-semantic-detector"
+        assert finding["severity"] == "medium"
+        assert finding["location"]["file"] == str(contract)
+        assert finding["location"]["function"] == "setOwner"
+
+
 class TestScan:
     def test_missing_contract_raises(self, scanner_all_available, tmp_path):
         with pytest.raises(FileNotFoundError):
@@ -190,6 +214,28 @@ class TestScan:
         result = scanner.scan(str(contract))
         assert result["tools_run"] == []
         assert result["summary"]["total_findings"] == 0
+
+    def test_scan_runs_local_access_control_without_external_tools(self, tmp_path):
+        contract = tmp_path / "Vault.sol"
+        contract.write_text(
+            "pragma solidity ^0.8.0;\n"
+            "contract Vault {\n"
+            "  address public owner;\n"
+            "  function setOwner(address next) external {\n"
+            "    owner = next;\n"
+            "  }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        with patch("subprocess.run", return_value=_proc(returncode=0)):
+            scanner = QuickScanner()
+        scanner.available_tools = {"slither": False, "aderyn": False, "solhint": False}
+
+        result = scanner.scan(str(contract))
+
+        assert result["tools_run"] == ["access-control-semantic-detector"]
+        assert result["summary"]["total_findings"] >= 1
+        assert "missing-access-control" in {f["type"] for f in result["findings"]}
 
     def test_scan_survives_tool_exception(self, tmp_path):
         contract = tmp_path / "C.sol"


### PR DESCRIPTION
## Summary
- Run the built-in semantic access-control detector from QuickScanner after external tools.
- Normalize detector findings with a stable tool id, severity, file location, and function metadata.
- Add behavior tests proving local access-control findings are emitted even when external tools are unavailable.

## Validation
- python3 -m pytest tests/test_quick_scanner_behavior.py -q
- python3 -m pytest tests/test_result_aggregator.py tests/test_baseline.py tests/test_baseline_cli.py -q
- python3 -m ruff check miesc/core/quick_scanner.py tests/test_quick_scanner_behavior.py
- python3 -m py_compile miesc/core/quick_scanner.py tests/test_quick_scanner_behavior.py
- git diff --check origin/main...HEAD