### PR TITLE
feat(formal): wire economic invariant synthesis into verify + ERC4626/solvency templates (Tier-2)

### DIFF
--- a/miesc/adapters/invariant_synthesizer.py
+++ b/miesc/adapters/invariant_synthesizer.py
@@ -58,6 +58,7 @@ class InvariantCategory(Enum):
 
     ACCOUNTING = "accounting"  # Balance/supply consistency
     SOLVENCY = "solvency"  # Vault/protocol solvency
+    ECONOMIC = "economic"  # Price/share-value/flash-loan business logic
     ACCESS_CONTROL = "access_control"  # Permission invariants
     STATE_TRANSITION = "state_transition"  # Valid state transitions
     REENTRANCY = "reentrancy"  # Reentrancy guards
@@ -147,6 +148,7 @@ class InvariantSynthesizer:
         categories: Optional[List[InvariantCategory]] = None,
         max_invariants: int = 20,
         use_cache: bool = True,
+        include_economic: bool = True,
     ) -> Dict[str, Any]:
         """
         Synthesize invariants for a smart contract.
@@ -157,6 +159,10 @@ class InvariantSynthesizer:
             categories: Categories to focus on (default: all)
             max_invariants: Maximum number of invariants to generate
             use_cache: Whether to use cached results
+            include_economic: Also emit economic/business-logic invariant
+                templates (share-price inflation, solvency, flash-loan
+                resistance) for the relevant contract type. Offline,
+                no external tool required.
 
         Returns:
             Dictionary with synthesized invariants and metadata
@@ -180,7 +186,7 @@ class InvariantSynthesizer:
                 return self._error_result(f"Could not read contract: {contract_path}", start_time)
 
             # Check cache
-            cache_key = self._get_cache_key(contract_code, formats, categories)
+            cache_key = self._get_cache_key(contract_code, formats, categories, include_economic)
             if use_cache:
                 cached = self._get_cached_result(cache_key)
                 if cached:
@@ -189,18 +195,28 @@ class InvariantSynthesizer:
                     return cached
 
             # Stage 1: Static pattern-based invariants
-            logger.info("Stage 1/3: Pattern-based invariant detection")
+            logger.info("Stage 1/4: Pattern-based invariant detection")
             pattern_invariants = self._detect_pattern_invariants(contract_code)
 
-            # Stage 2: LLM-generated invariants
-            logger.info("Stage 2/3: LLM invariant synthesis")
+            # Stage 2: Economic / business-logic invariant templates (offline)
+            economic_invariants: List[SynthesizedInvariant] = []
+            if include_economic:
+                logger.info("Stage 2/4: Economic invariant templates")
+                economic_invariants = self._detect_economic_invariants(contract_code)
+
+            # Stage 3: LLM-generated invariants
+            logger.info("Stage 3/4: LLM invariant synthesis")
             llm_invariants = self._synthesize_with_llm(
                 contract_code, contract_path, categories, max_invariants
             )
 
-            # Stage 3: Merge and format
-            logger.info("Stage 3/3: Merging and formatting invariants")
-            all_invariants = self._merge_invariants(pattern_invariants, llm_invariants)
+            # Stage 4: Merge and format
+            logger.info("Stage 4/4: Merging and formatting invariants")
+            # Economic templates carry concrete, pre-populated backend bodies and
+            # take precedence over the generic pattern/LLM output.
+            all_invariants = self._merge_invariants(
+                economic_invariants + pattern_invariants, llm_invariants
+            )
 
             # Generate multi-format output
             formatted_invariants = self._format_invariants(all_invariants, formats)
@@ -218,6 +234,7 @@ class InvariantSynthesizer:
                 "metadata": {
                     "model": self._model,
                     "pattern_invariants": len(pattern_invariants),
+                    "economic_invariants": len(economic_invariants),
                     "llm_invariants": len(llm_invariants),
                     "rag_patterns_used": len(self._formal_invariants),
                 },
@@ -367,6 +384,42 @@ class InvariantSynthesizer:
             )
 
         logger.info(f"Pattern detection found {len(invariants)} invariants")
+        return invariants
+
+    def _detect_economic_invariants(self, contract_code: str) -> List[SynthesizedInvariant]:
+        """Build economic/business-logic invariants from the template library.
+
+        Offline and deterministic — no external tool required. Each template
+        carries concrete Certora/Echidna/Foundry bodies which are preserved
+        verbatim through the formatting stage (see `_format_invariants`).
+        """
+        from miesc.formal.economic_invariants import detect_economic_invariants
+
+        invariants: List[SynthesizedInvariant] = []
+        for tmpl in detect_economic_invariants(contract_code):
+            try:
+                category = InvariantCategory(tmpl.get("category", "economic"))
+            except ValueError:
+                category = InvariantCategory.ECONOMIC
+
+            invariants.append(
+                SynthesizedInvariant(
+                    name=tmpl["name"],
+                    description=tmpl["natural_language"],
+                    category=category,
+                    importance=tmpl.get("importance", "HIGH"),
+                    natural_language=tmpl["natural_language"],
+                    certora_spec=tmpl.get("certora_spec"),
+                    echidna_property=tmpl.get("echidna_property"),
+                    foundry_test=tmpl.get("foundry_test"),
+                    confidence=0.85,
+                    source="economic-template",
+                    related_vulnerabilities=tmpl.get("related_vulnerabilities", []),
+                    metadata={"auto_checkable": tmpl.get("auto_checkable", True)},
+                )
+            )
+
+        logger.info(f"Economic templates matched {len(invariants)} invariants")
         return invariants
 
     def _synthesize_with_llm(
@@ -601,21 +654,25 @@ IMPORTANT RULES:
         invariants: List[SynthesizedInvariant],
         formats: List[InvariantFormat],
     ) -> List[SynthesizedInvariant]:
-        """Generate multi-format output for invariants."""
+        """Generate multi-format output for invariants.
+
+        Pre-populated bodies (e.g. concrete economic templates) are preserved —
+        only empty fields are filled by the generic emitters.
+        """
         for inv in invariants:
-            if InvariantFormat.SOLIDITY in formats:
+            if InvariantFormat.SOLIDITY in formats and not inv.solidity_assertion:
                 inv.solidity_assertion = self._to_solidity(inv)
 
-            if InvariantFormat.CERTORA in formats:
+            if InvariantFormat.CERTORA in formats and not inv.certora_spec:
                 inv.certora_spec = self._to_certora(inv)
 
-            if InvariantFormat.ECHIDNA in formats:
+            if InvariantFormat.ECHIDNA in formats and not inv.echidna_property:
                 inv.echidna_property = self._to_echidna(inv)
 
-            if InvariantFormat.HALMOS in formats:
+            if InvariantFormat.HALMOS in formats and not inv.halmos_test:
                 inv.halmos_test = self._to_halmos(inv)
 
-            if InvariantFormat.FOUNDRY in formats:
+            if InvariantFormat.FOUNDRY in formats and not inv.foundry_test:
                 inv.foundry_test = self._to_foundry(inv)
 
         return invariants
@@ -865,10 +922,14 @@ function invariant_{name}() public {{
         contract_code: str,
         formats: List[InvariantFormat],
         categories: List[InvariantCategory],
+        include_economic: bool = True,
     ) -> str:
         """Generate cache key."""
         content = (
-            contract_code + str([f.value for f in formats]) + str([c.value for c in categories])
+            contract_code
+            + str([f.value for f in formats])
+            + str([c.value for c in categories])
+            + f"econ={include_economic}"
         )
         return hashlib.sha256(content.encode()).hexdigest()
 

--- a/miesc/cli/commands/verify.py
+++ b/miesc/cli/commands/verify.py
@@ -25,6 +25,95 @@ def _find_foundry_root(start: Path) -> Optional[Path]:
     return None
 
 
+def _emit_economic_invariants(
+    contract_path: str,
+    out_dir: Optional[str],
+    quiet: bool,
+) -> Dict[str, Any]:
+    """Synthesize economic/business-logic invariants for a contract and emit them.
+
+    Contract-driven (not finding-driven): reads the source, matches economic
+    invariant templates (share-price inflation, solvency, flash-loan resistance,
+    supply conservation) and emits CVL + Echidna + Foundry artifacts.
+
+    Fully offline — requires no prover/fuzzer. When Ollama is available the
+    synthesizer additionally augments with LLM invariants, but that is optional.
+
+    Returns a summary dict: {count, names, files}.
+    """
+    from miesc.adapters.invariant_synthesizer import InvariantFormat, InvariantSynthesizer
+
+    synth = InvariantSynthesizer()
+    result = synth.synthesize(
+        contract_path=contract_path,
+        formats=[
+            InvariantFormat.CERTORA,
+            InvariantFormat.ECHIDNA,
+            InvariantFormat.FOUNDRY,
+        ],
+        include_economic=True,
+        use_cache=False,
+    )
+
+    economic_categories = {"economic", "solvency", "accounting"}
+    invariants = [
+        inv for inv in result.get("invariants", []) if inv.get("category") in economic_categories
+    ]
+
+    names = [inv.get("name", "unnamed") for inv in invariants]
+    files: list[str] = []
+
+    if out_dir and invariants:
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        stem = Path(contract_path).stem
+
+        import json as _json
+
+        json_path = out / f"{stem}.economic-invariants.json"
+        json_path.write_text(
+            _json.dumps({"contract": contract_path, "invariants": invariants}, indent=2),
+            encoding="utf-8",
+        )
+        files.append(str(json_path))
+
+        cvl = ["// Auto-generated economic invariants (CANDIDATES — bind protocol state).", ""]
+        ech = ["// Auto-generated economic Echidna properties (CANDIDATES).", ""]
+        fnd = ["// Auto-generated economic Foundry invariants (CANDIDATES).", ""]
+        for inv in invariants:
+            header = (
+                f"// [{inv.get('importance')}] {inv.get('name')}: {inv.get('natural_language')}"
+            )
+            if inv.get("certora_spec"):
+                cvl += [header, inv["certora_spec"], ""]
+            if inv.get("echidna_property"):
+                ech += [header, inv["echidna_property"], ""]
+            if inv.get("foundry_test"):
+                fnd += [header, inv["foundry_test"], ""]
+
+        cvl_path = out / f"{stem}.economic.spec"
+        ech_path = out / f"{stem}.economic.echidna.sol"
+        fnd_path = out / f"{stem}.economic.invariants.t.sol"
+        cvl_path.write_text("\n".join(cvl), encoding="utf-8")
+        ech_path.write_text("\n".join(ech), encoding="utf-8")
+        fnd_path.write_text("\n".join(fnd), encoding="utf-8")
+        files += [str(cvl_path), str(ech_path), str(fnd_path)]
+
+    if not quiet:
+        if invariants:
+            console.print(f"\n[bold]Economic invariants:[/bold] {len(invariants)} generated")
+            for inv in invariants:
+                console.print(f"  • [{inv.get('importance')}] {inv.get('name')}")
+            for f in files:
+                success(f"Wrote {f}")
+            if not out_dir:
+                info("Pass --invariants-out DIR to write CVL/Echidna/Foundry artifacts.")
+        else:
+            info("No economic invariant templates matched this contract.")
+
+    return {"count": len(invariants), "names": names, "files": files}
+
+
 @click.command()
 @click.argument("contract_path", type=click.Path(exists=True))
 @click.option(
@@ -80,6 +169,19 @@ def _find_foundry_root(start: Path) -> Optional[Path]:
     help="With --poc: run 'forge build' on each scaffold to confirm it compiles "
     "(best-effort; skipped when forge is not installed).",
 )
+@click.option(
+    "--economic-invariants",
+    is_flag=True,
+    help="Synthesize economic/business-logic invariants (ERC-4626 share-price "
+    "inflation, solvency, flash-loan resistance) from the contract and emit them. "
+    "Offline; no prover/fuzzer required.",
+)
+@click.option(
+    "--invariants-out",
+    type=click.Path(),
+    default=None,
+    help="With --economic-invariants: directory to write CVL/Echidna/Foundry artifacts.",
+)
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 def verify(
     contract_path: str,
@@ -91,6 +193,8 @@ def verify(
     sarif: str | None,
     poc: str | None,
     poc_check: bool,
+    economic_invariants: bool,
+    invariants_out: str | None,
     quiet: bool,
 ) -> None:
     """Run formal-verification provers against a contract.
@@ -109,6 +213,15 @@ def verify(
     """
     if not quiet:
         print_banner()
+
+    # Economic / business-logic invariant synthesis (offline, prover-independent).
+    econ_summary: Optional[Dict[str, Any]] = None
+    if economic_invariants:
+        try:
+            econ_summary = _emit_economic_invariants(contract_path, invariants_out, quiet)
+        except Exception as e:  # pragma: no cover - defensive
+            error(f"Economic invariant synthesis failed: {e}")
+            sys.exit(1)
 
     try:
         from miesc.formal import SpecRunner
@@ -203,6 +316,9 @@ def verify(
             sys.exit(1)
 
     if not results:
+        if econ_summary is not None:
+            # Economic invariant emission already did useful, prover-independent work.
+            sys.exit(0)
         warning("No provers were run (none installed for selected --tool).")
         sys.exit(0)
 

--- a/miesc/formal/__init__.py
+++ b/miesc/formal/__init__.py
@@ -8,6 +8,11 @@ Bridges MIESC findings to formal verification tools:
   - Halmos (symbolic testing)
 """
 
+from miesc.formal.economic_invariants import (
+    ECONOMIC_INVARIANT_TEMPLATES,
+    EconomicInvariantTemplate,
+    detect_economic_invariants,
+)
 from miesc.formal.spec_generator import (
     GeneratedSpec,
     SpecFormat,
@@ -28,6 +33,8 @@ from miesc.formal.unified_report import (
 
 __all__ = [
     "Counterexample",
+    "ECONOMIC_INVARIANT_TEMPLATES",
+    "EconomicInvariantTemplate",
     "GeneratedSpec",
     "ProverVerdict",
     "SpecFormat",
@@ -36,6 +43,7 @@ __all__ = [
     "UNAVAILABLE",
     "UnifiedVerificationReport",
     "VerificationResult",
+    "detect_economic_invariants",
     "normalize_status",
     "run_all_available",
 ]

--- a/miesc/formal/economic_invariants.py
+++ b/miesc/formal/economic_invariants.py
@@ -1,0 +1,400 @@
+"""
+Economic / business-logic invariant templates.
+================================================
+
+The pure-static detection layer is structurally blind to *economic* exploits —
+price manipulation, ERC-4626 share-price inflation, flash-loan-assisted
+draining, and general accounting/solvency violations. These are not pattern
+matches on the AST; they are *properties* a protocol must preserve across every
+transaction. The right tool for them is a prover or a fuzzer, and both need the
+property written down first.
+
+This module is that "written down" step: a small, honest library of economic
+invariant TEMPLATES for the classes our benchmark flagged as out-of-scope for
+static analysis:
+
+  * ERC-4626 share-price inflation  (share price monotonic / first-deposit guard)
+  * Solvency                        (backing assets >= accounted liabilities)
+  * Flash-loan resistance           (price not derived from intra-tx spot balance)
+  * Accounting conservation         (sum of balances == totalSupply)
+  * No-withdraw-exceeds-deposit     (a user cannot extract more than they put in)
+
+Honesty note: these templates EXPRESS a property to prove or fuzz. They do not,
+by themselves, *detect* an economic exploit — they are the input a Certora /
+Halmos / Echidna / Foundry-invariant run consumes. Bind the protocol-specific
+state variables and actors before treating any counterexample as evidence.
+
+Author: Fernando Boiero <fboiero@frvm.utn.edu.ar>
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+# =============================================================================
+# Template data model
+# =============================================================================
+
+
+@dataclass
+class EconomicInvariantTemplate:
+    """A concrete, honest economic invariant with multi-backend bodies."""
+
+    name: str
+    category: str  # accounting | solvency | economic
+    importance: str  # CRITICAL | HIGH | MEDIUM | LOW
+    natural_language: str
+    certora_spec: str
+    echidna_property: str
+    foundry_test: str
+    related_vulnerabilities: List[str] = field(default_factory=list)
+    # Whether the property can, in principle, be discharged automatically by a
+    # prover/fuzzer (True) or fundamentally needs a manual binding / review
+    # (False, e.g. flash-loan oracle provenance).
+    auto_checkable: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "category": self.category,
+            "importance": self.importance,
+            "natural_language": self.natural_language,
+            "certora_spec": self.certora_spec,
+            "echidna_property": self.echidna_property,
+            "foundry_test": self.foundry_test,
+            "related_vulnerabilities": list(self.related_vulnerabilities),
+            "auto_checkable": self.auto_checkable,
+            "source": "economic-template",
+        }
+
+
+_CANDIDATE_NOTE = (
+    "// CANDIDATE property — bind protocol-specific state/actors before use as evidence."
+)
+
+
+# =============================================================================
+# Template library
+# =============================================================================
+
+ERC4626_SHARE_PRICE_NON_DECREASING = EconomicInvariantTemplate(
+    name="erc4626_share_price_non_decreasing",
+    category="economic",
+    importance="CRITICAL",
+    natural_language=(
+        "The price per share (convertToAssets of a fixed share amount) must never "
+        "decrease as a result of a deposit or mint. A sudden jump/drop is the "
+        "signature of an inflation / donation attack where an attacker front-runs "
+        "the first depositor to steal their assets via rounding."
+    ),
+    related_vulnerabilities=["erc4626-inflation", "share-price-manipulation", "SWC-132"],
+    certora_spec=f"""// ERC-4626 share price must not decrease on deposit/mint
+{_CANDIDATE_NOTE}
+rule sharePriceNonDecreasing(env e, uint256 assets, address receiver) {{
+    uint256 unit = 10^18;
+    uint256 ppsBefore = convertToAssets(unit);
+    deposit(e, assets, receiver);
+    uint256 ppsAfter = convertToAssets(unit);
+    assert ppsAfter >= ppsBefore,
+        "Share price decreased on deposit (inflation attack signature)";
+}}""",
+    echidna_property=f"""// Track the worst-observed price-per-share; it must never regress.
+{_CANDIDATE_NOTE}
+uint256 private _lastPricePerShare = type(uint256).max;
+function echidna_share_price_non_decreasing() public returns (bool) {{
+    if (totalSupply() == 0) return true;
+    uint256 pps = convertToAssets(1e18);
+    bool ok = pps >= _lastPricePerShare || _lastPricePerShare == type(uint256).max;
+    if (pps < _lastPricePerShare) _lastPricePerShare = pps;
+    return ok;
+}}""",
+    foundry_test=f"""// Foundry stateful invariant: price per share is monotonic non-decreasing.
+{_CANDIDATE_NOTE}
+uint256 internal _ppsFloor;
+function invariant_sharePriceNonDecreasing() public {{
+    if (vault.totalSupply() == 0) return;
+    uint256 pps = vault.convertToAssets(1e18);
+    assertGe(pps, _ppsFloor, "share price regressed (inflation attack)");
+    if (pps > _ppsFloor) _ppsFloor = pps;
+}}""",
+)
+
+ERC4626_FIRST_DEPOSIT_GUARD = EconomicInvariantTemplate(
+    name="erc4626_first_deposit_guard",
+    category="economic",
+    importance="CRITICAL",
+    natural_language=(
+        "The first deposit into the vault must not let an attacker inflate the "
+        "share price to a level that rounds subsequent deposits down to zero "
+        "shares. Mitigations: mint dead shares to address(0) at init, or use "
+        "OpenZeppelin's virtual-shares/virtual-assets offset."
+    ),
+    related_vulnerabilities=["erc4626-inflation", "first-deposit-attack"],
+    certora_spec=f"""// A non-zero deposit must always mint a non-zero number of shares.
+{_CANDIDATE_NOTE}
+rule firstDepositMintsShares(env e, uint256 assets, address receiver) {{
+    require assets > 0;
+    uint256 shares = deposit(e, assets, receiver);
+    assert shares > 0,
+        "Deposit rounded to zero shares (first-deposit inflation attack)";
+}}""",
+    echidna_property=f"""// Any positive deposit must yield positive shares.
+{_CANDIDATE_NOTE}
+function echidna_deposit_mints_nonzero_shares() public returns (bool) {{
+    if (totalAssets() == 0) return true;
+    return convertToShares(1) > 0 || totalSupply() == 0;
+}}""",
+    foundry_test=f"""// Foundry: a 1-wei deposit against a funded vault must not round to 0 shares.
+{_CANDIDATE_NOTE}
+function invariant_depositMintsNonZeroShares() public {{
+    if (vault.totalAssets() == 0) return;
+    assertGt(vault.convertToShares(1e6), 0, "small deposit rounds to zero shares");
+}}""",
+)
+
+VAULT_SOLVENCY = EconomicInvariantTemplate(
+    name="vault_solvency",
+    category="solvency",
+    importance="CRITICAL",
+    natural_language=(
+        "The vault must always hold enough backing assets to honour every share: "
+        "totalAssets() >= convertToAssets(totalSupply()). If accounted liabilities "
+        "exceed real backing the protocol is insolvent and a bank-run can drain it."
+    ),
+    related_vulnerabilities=["vault-insolvency", "accounting-mismatch"],
+    certora_spec=f"""// Backing assets must cover all outstanding shares.
+{_CANDIDATE_NOTE}
+invariant vaultSolvency()
+    totalAssets() >= convertToAssets(totalSupply())
+{{
+    preserved {{
+        requireInvariant vaultSolvency();
+    }}
+}}""",
+    echidna_property=f"""// Backing must always cover liabilities.
+{_CANDIDATE_NOTE}
+function echidna_vault_solvent() public view returns (bool) {{
+    return totalAssets() >= convertToAssets(totalSupply());
+}}""",
+    foundry_test=f"""// Foundry: real backing >= accounted liabilities at all times.
+{_CANDIDATE_NOTE}
+function invariant_vaultSolvency() public {{
+    assertGe(
+        vault.totalAssets(),
+        vault.convertToAssets(vault.totalSupply()),
+        "vault insolvent: backing < liabilities"
+    );
+}}""",
+)
+
+NO_WITHDRAW_EXCEEDS_DEPOSIT = EconomicInvariantTemplate(
+    name="no_withdraw_exceeds_deposit",
+    category="accounting",
+    importance="HIGH",
+    natural_language=(
+        "A user must not be able to withdraw more underlying than they deposited "
+        "plus any legitimately accrued yield. Track per-account deposited and "
+        "withdrawn; withdrawn <= deposited + yieldCredited[account]."
+    ),
+    related_vulnerabilities=["accounting-drain", "business-logic"],
+    certora_spec=f"""// A user cannot extract more than they put in (+ accrued yield).
+{_CANDIDATE_NOTE}
+rule noWithdrawExceedsDeposit(env e, uint256 assets, address owner) {{
+    // ghost trackers `deposited` and `yieldCredited` must be wired in the harness.
+    uint256 out = withdraw(e, assets, e.msg.sender, owner);
+    assert withdrawn[owner] + out <= deposited[owner] + yieldCredited[owner],
+        "User withdrew more than deposited + yield";
+}}""",
+    echidna_property=f"""// Cumulative withdrawn must never exceed deposited + credited yield.
+{_CANDIDATE_NOTE}
+function echidna_no_withdraw_exceeds_deposit() public view returns (bool) {{
+    return _withdrawn[msg.sender] <= _deposited[msg.sender] + _yieldCredited[msg.sender];
+}}""",
+    foundry_test=f"""// Foundry: no account extracts more than it contributed (+ yield).
+{_CANDIDATE_NOTE}
+function invariant_noWithdrawExceedsDeposit() public {{
+    address[] memory actors = handler.actors();
+    for (uint256 i = 0; i < actors.length; i++) {{
+        assertLe(
+            handler.withdrawn(actors[i]),
+            handler.deposited(actors[i]) + handler.yieldCredited(actors[i]),
+            "account extracted more than deposited + yield"
+        );
+    }}
+}}""",
+)
+
+TOTAL_SUPPLY_EQUALS_SUM_BALANCES = EconomicInvariantTemplate(
+    name="total_supply_equals_sum_balances",
+    category="accounting",
+    importance="CRITICAL",
+    natural_language=(
+        "The total supply must always equal the sum of all account balances. A "
+        "divergence means tokens were minted or burned off the books — the root "
+        "cause of most accounting-drain exploits."
+    ),
+    related_vulnerabilities=["accounting-mismatch", "SWC-132"],
+    certora_spec=f"""// Conservation of supply: totalSupply == sum of balances.
+{_CANDIDATE_NOTE}
+// Requires a `sumBalances` ghost summed over balanceOf in the harness.
+invariant totalSupplyEqualsSumBalances()
+    totalSupply() == sumBalances()
+{{
+    preserved {{
+        requireInvariant totalSupplyEqualsSumBalances();
+    }}
+}}""",
+    echidna_property=f"""// The tracked running sum of balances must equal totalSupply.
+{_CANDIDATE_NOTE}
+function echidna_supply_equals_sum_balances() public view returns (bool) {{
+    return totalSupply() == _sumOfBalances;
+}}""",
+    foundry_test=f"""// Foundry: ghost-summed balances equal totalSupply after every action.
+{_CANDIDATE_NOTE}
+function invariant_totalSupplyEqualsSumBalances() public {{
+    assertEq(token.totalSupply(), handler.sumBalances(), "supply != sum(balances)");
+}}""",
+)
+
+PRICE_NOT_FROM_SPOT_BALANCE = EconomicInvariantTemplate(
+    name="price_not_from_spot_balance",
+    category="economic",
+    importance="HIGH",
+    natural_language=(
+        "A price/oracle used for accounting must NOT be derived from a spot token "
+        "balance readable within a single transaction (e.g. token.balanceOf(pair) "
+        "or getReserves()). Such prices are flash-loan manipulable. Use a TWAP or "
+        "an external oracle (Chainlink) instead. This property fundamentally needs "
+        "manual review of the price source; the auto-checkable proxy below asserts "
+        "that a quoted price is unchanged by a same-block balance perturbation."
+    ),
+    related_vulnerabilities=["flash-loan", "oracle-manipulation", "price-manipulation"],
+    auto_checkable=False,
+    certora_spec=f"""// Proxy for flash-loan resistance: a same-tx balance donation must not move
+// the quoted price. Full resistance still requires manual oracle-source review.
+{_CANDIDATE_NOTE}
+rule priceImmuneToSpotDonation(env e, uint256 donation) {{
+    uint256 priceBefore = getPrice(e);
+    // Model a flash-loan donation into the pool/pair within the same tx.
+    simulateDonation(e, donation);
+    uint256 priceAfter = getPrice(e);
+    assert priceAfter == priceBefore,
+        "Quoted price moved by an intra-tx balance donation (flash-loan manipulable)";
+}}""",
+    echidna_property=f"""// A donated balance must not change the quoted price within the tx.
+{_CANDIDATE_NOTE}
+function echidna_price_immune_to_spot_donation() public returns (bool) {{
+    uint256 p0 = _quotedPrice();
+    _donateForTest(1e18);   // simulate flash-loan inflow
+    return _quotedPrice() == p0;
+}}""",
+    foundry_test=f"""// Foundry: quoted price must be independent of a same-block spot donation.
+{_CANDIDATE_NOTE}
+function invariant_priceImmuneToSpotDonation() public {{
+    uint256 p0 = oracle.price();
+    deal(address(underlying), address(pair), underlying.balanceOf(address(pair)) + 1e24);
+    assertEq(oracle.price(), p0, "price moved by spot-balance donation (flash-loan risk)");
+}}""",
+)
+
+
+# Full ordered library (used for listing / docs / tests).
+ECONOMIC_INVARIANT_TEMPLATES: Dict[str, EconomicInvariantTemplate] = {
+    t.name: t
+    for t in (
+        ERC4626_SHARE_PRICE_NON_DECREASING,
+        ERC4626_FIRST_DEPOSIT_GUARD,
+        VAULT_SOLVENCY,
+        NO_WITHDRAW_EXCEEDS_DEPOSIT,
+        TOTAL_SUPPLY_EQUALS_SUM_BALANCES,
+        PRICE_NOT_FROM_SPOT_BALANCE,
+    )
+}
+
+
+# =============================================================================
+# Contract-type-aware selection
+# =============================================================================
+
+
+def _looks_like_erc4626(code: str) -> bool:
+    cl = code.lower()
+    if "erc4626" in cl:
+        return True
+    signals = ("converttoassets", "converttoshares", "totalassets")
+    return sum(s in cl for s in signals) >= 2
+
+
+def _looks_like_vault(code: str) -> bool:
+    cl = code.lower()
+    return ("vault" in cl or "share" in cl) and "deposit" in cl and "withdraw" in cl
+
+
+def _looks_like_token(code: str) -> bool:
+    cl = code.lower()
+    return "totalsupply" in cl and "balanceof" in cl
+
+
+def _uses_spot_price(code: str) -> bool:
+    cl = code.lower()
+    spot_signals = (
+        "getreserves",
+        ".balanceof(address(this))",
+        "reserve0",
+        "reserve1",
+        "getamountout",
+    )
+    price_signals = ("price", "oracle", "quote", "swap", "amm", "liquidity")
+    return any(s in cl for s in spot_signals) and any(p in cl for p in price_signals)
+
+
+def detect_economic_invariants(contract_source: str) -> List[Dict[str, Any]]:
+    """Return economic invariant templates relevant to the given contract source.
+
+    Selection is heuristic and additive: ERC-4626 vaults get the full share-price /
+    solvency set; generic token contracts get supply-conservation; anything that
+    reads a spot price/reserve for accounting gets the flash-loan resistance proxy.
+
+    Args:
+        contract_source: Raw Solidity source of the contract under analysis.
+
+    Returns:
+        A list of template dicts (see EconomicInvariantTemplate.to_dict). Empty
+        list when nothing economic is recognised — an honest no-op.
+    """
+    if not contract_source:
+        return []
+
+    selected: List[EconomicInvariantTemplate] = []
+    is_4626 = _looks_like_erc4626(contract_source)
+    is_vault = is_4626 or _looks_like_vault(contract_source)
+
+    if is_vault:
+        selected.append(VAULT_SOLVENCY)
+        selected.append(NO_WITHDRAW_EXCEEDS_DEPOSIT)
+    if is_4626:
+        selected.append(ERC4626_SHARE_PRICE_NON_DECREASING)
+        selected.append(ERC4626_FIRST_DEPOSIT_GUARD)
+    if _looks_like_token(contract_source):
+        selected.append(TOTAL_SUPPLY_EQUALS_SUM_BALANCES)
+    if _uses_spot_price(contract_source):
+        selected.append(PRICE_NOT_FROM_SPOT_BALANCE)
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    ordered: List[EconomicInvariantTemplate] = []
+    for t in selected:
+        if t.name not in seen:
+            ordered.append(t)
+            seen.add(t.name)
+
+    return [t.to_dict() for t in ordered]
+
+
+__all__ = [
+    "EconomicInvariantTemplate",
+    "ECONOMIC_INVARIANT_TEMPLATES",
+    "detect_economic_invariants",
+]

--- a/tests/test_economic_invariants.py
+++ b/tests/test_economic_invariants.py
@@ -1,0 +1,132 @@
+"""
+Tests for miesc/formal/economic_invariants.py
+
+Covers:
+  - Template library completeness and structure
+  - Contract-type-aware selection (ERC-4626, generic vault, token, AMM/spot-price)
+  - Honest no-op on empty / non-economic input
+  - Flash-loan resistance template is flagged not-auto-checkable (honesty)
+  - Every template carries CVL + Echidna + Foundry bodies
+"""
+
+from __future__ import annotations
+
+from miesc.formal.economic_invariants import (
+    ECONOMIC_INVARIANT_TEMPLATES,
+    EconomicInvariantTemplate,
+    detect_economic_invariants,
+)
+
+ERC4626_VAULT = """
+pragma solidity ^0.8.0;
+contract Vault {
+    uint256 public totalSupply;
+    function totalAssets() public view returns (uint256) {}
+    function convertToShares(uint256 a) public view returns (uint256) {}
+    function convertToAssets(uint256 s) public view returns (uint256) {}
+    function deposit(uint256 a, address r) public returns (uint256) {}
+    function withdraw(uint256 a, address r, address o) public returns (uint256) {}
+}
+"""
+
+PLAIN_TOKEN = """
+pragma solidity ^0.8.0;
+contract Token {
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    function transfer(address to, uint256 amt) public returns (bool) {}
+}
+"""
+
+AMM_WITH_SPOT_PRICE = """
+pragma solidity ^0.8.0;
+contract Oracle {
+    function getReserves() public view returns (uint112 reserve0, uint112 reserve1) {}
+    function price() public view returns (uint256) {
+        (uint112 r0, uint112 r1) = getReserves();
+        return uint256(r1) / uint256(r0); // spot price -> flash-loan manipulable
+    }
+}
+"""
+
+NON_ECONOMIC = """
+pragma solidity ^0.8.0;
+contract Counter { uint256 public count; function inc() public { count++; } }
+"""
+
+
+class TestTemplateLibrary:
+    def test_expected_templates_present(self):
+        expected = {
+            "erc4626_share_price_non_decreasing",
+            "erc4626_first_deposit_guard",
+            "vault_solvency",
+            "no_withdraw_exceeds_deposit",
+            "total_supply_equals_sum_balances",
+            "price_not_from_spot_balance",
+        }
+        assert expected.issubset(set(ECONOMIC_INVARIANT_TEMPLATES))
+
+    def test_every_template_has_all_backend_bodies(self):
+        for name, tmpl in ECONOMIC_INVARIANT_TEMPLATES.items():
+            assert isinstance(tmpl, EconomicInvariantTemplate)
+            assert tmpl.certora_spec.strip(), f"{name} missing CVL"
+            assert tmpl.echidna_property.strip(), f"{name} missing Echidna"
+            assert tmpl.foundry_test.strip(), f"{name} missing Foundry"
+            assert tmpl.importance in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+            assert tmpl.category in {"accounting", "solvency", "economic"}
+
+    def test_to_dict_roundtrip(self):
+        d = ECONOMIC_INVARIANT_TEMPLATES["vault_solvency"].to_dict()
+        assert d["name"] == "vault_solvency"
+        assert d["source"] == "economic-template"
+        assert "certora_spec" in d and "echidna_property" in d and "foundry_test" in d
+
+
+class TestDetection:
+    def test_erc4626_gets_full_economic_set(self):
+        names = {i["name"] for i in detect_economic_invariants(ERC4626_VAULT)}
+        assert "erc4626_share_price_non_decreasing" in names
+        assert "erc4626_first_deposit_guard" in names
+        assert "vault_solvency" in names
+        assert "no_withdraw_exceeds_deposit" in names
+
+    def test_plain_token_gets_supply_conservation(self):
+        names = {i["name"] for i in detect_economic_invariants(PLAIN_TOKEN)}
+        assert "total_supply_equals_sum_balances" in names
+        # A plain token is not a vault -> no share-price invariants
+        assert "erc4626_share_price_non_decreasing" not in names
+
+    def test_amm_spot_price_gets_flash_loan_template(self):
+        names = {i["name"] for i in detect_economic_invariants(AMM_WITH_SPOT_PRICE)}
+        assert "price_not_from_spot_balance" in names
+
+    def test_non_economic_contract_is_honest_noop(self):
+        assert detect_economic_invariants(NON_ECONOMIC) == []
+
+    def test_empty_source_returns_empty(self):
+        assert detect_economic_invariants("") == []
+
+    def test_no_duplicate_names(self):
+        results = detect_economic_invariants(ERC4626_VAULT)
+        names = [i["name"] for i in results]
+        assert len(names) == len(set(names))
+
+
+class TestHonesty:
+    def test_flash_loan_template_not_auto_checkable(self):
+        """Flash-loan resistance fundamentally needs manual oracle-source review;
+        the template must honestly flag that it is not fully auto-checkable."""
+        tmpl = ECONOMIC_INVARIANT_TEMPLATES["price_not_from_spot_balance"]
+        assert tmpl.auto_checkable is False
+
+    def test_solvency_and_supply_are_auto_checkable(self):
+        assert ECONOMIC_INVARIANT_TEMPLATES["vault_solvency"].auto_checkable is True
+        assert (
+            ECONOMIC_INVARIANT_TEMPLATES["total_supply_equals_sum_balances"].auto_checkable is True
+        )
+
+    def test_templates_marked_as_candidates(self):
+        """Emitted bodies must be labelled CANDIDATE — they are not proven evidence."""
+        for tmpl in ECONOMIC_INVARIANT_TEMPLATES.values():
+            assert "CANDIDATE" in tmpl.certora_spec

--- a/tests/test_invariant_synthesizer.py
+++ b/tests/test_invariant_synthesizer.py
@@ -198,13 +198,14 @@ class TestInvariantCategory:
     def test_all_categories(self):
         assert InvariantCategory.ACCOUNTING.value == "accounting"
         assert InvariantCategory.SOLVENCY.value == "solvency"
+        assert InvariantCategory.ECONOMIC.value == "economic"
         assert InvariantCategory.ACCESS_CONTROL.value == "access_control"
         assert InvariantCategory.STATE_TRANSITION.value == "state_transition"
         assert InvariantCategory.REENTRANCY.value == "reentrancy"
         assert InvariantCategory.OVERFLOW.value == "overflow"
         assert InvariantCategory.TEMPORAL.value == "temporal"
         assert InvariantCategory.CUSTOM.value == "custom"
-        assert len(InvariantCategory) == 8
+        assert len(InvariantCategory) == 9
 
     def test_category_from_value(self):
         assert InvariantCategory("accounting") == InvariantCategory.ACCOUNTING
@@ -1045,3 +1046,88 @@ class TestSynthesizeInvariantsConvenience:
                 ):
                     result = synthesize_invariants("/nonexistent/file.sol")
         assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Economic invariant wiring (dead-code -> live)
+# ---------------------------------------------------------------------------
+
+ERC4626_VAULT_SRC = """
+pragma solidity ^0.8.0;
+contract Vault {
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    function totalAssets() public view returns (uint256) {}
+    function convertToShares(uint256 a) public view returns (uint256) {}
+    function convertToAssets(uint256 s) public view returns (uint256) {}
+    function deposit(uint256 a, address r) public returns (uint256) {}
+    function withdraw(uint256 a, address r, address o) public returns (uint256) {}
+}
+"""
+
+
+def _write_vault(tmp_path):
+    p = tmp_path / "Vault.sol"
+    p.write_text(ERC4626_VAULT_SRC)
+    return str(p)
+
+
+class TestEconomicInvariantWiring:
+    def _synth(self):
+        with (
+            patch(
+                "miesc.adapters.invariant_synthesizer.get_model", return_value="deepseek-coder:6.7b"
+            ),
+            patch(
+                "miesc.adapters.invariant_synthesizer.get_ollama_host",
+                return_value="http://localhost:11434",
+            ),
+            patch(
+                "miesc.adapters.invariant_synthesizer.get_retry_config",
+                return_value={"attempts": 1, "delay": 0},
+            ),
+            patch(
+                "miesc.adapters.invariant_synthesizer.InvariantSynthesizer._is_ollama_available",
+                return_value=False,
+            ),
+        ):
+            return InvariantSynthesizer()
+
+    def test_economic_invariants_generated_for_vault(self, tmp_path):
+        synth = self._synth()
+        result = synth.synthesize(
+            _write_vault(tmp_path),
+            formats=[InvariantFormat.CERTORA, InvariantFormat.ECHIDNA, InvariantFormat.FOUNDRY],
+            use_cache=False,
+        )
+        assert result["status"] == "success"
+        assert result["metadata"]["economic_invariants"] >= 3
+        econ = [i for i in result["invariants"] if i["source"] == "economic-template"]
+        names = {i["name"] for i in econ}
+        assert "vault_solvency" in names
+        assert "erc4626_share_price_non_decreasing" in names
+
+    def test_economic_bodies_are_concrete_not_placeholder(self, tmp_path):
+        """Economic templates carry real bodies that survive the format stage —
+        they must NOT be overwritten by the generic candidatePredicate() emitter."""
+        synth = self._synth()
+        result = synth.synthesize(
+            _write_vault(tmp_path),
+            formats=[InvariantFormat.CERTORA, InvariantFormat.ECHIDNA, InvariantFormat.FOUNDRY],
+            use_cache=False,
+        )
+        solvency = next(i for i in result["invariants"] if i["name"] == "vault_solvency")
+        assert "totalAssets() >= convertToAssets(totalSupply())" in solvency["certora_spec"]
+        assert "candidatePredicate" not in solvency["echidna_property"]
+        assert "assertGe" in solvency["foundry_test"]
+
+    def test_include_economic_false_disables_stage(self, tmp_path):
+        synth = self._synth()
+        result = synth.synthesize(
+            _write_vault(tmp_path),
+            formats=[InvariantFormat.CERTORA],
+            use_cache=False,
+            include_economic=False,
+        )
+        assert result["metadata"]["economic_invariants"] == 0
+        assert not any(i["source"] == "economic-template" for i in result["invariants"])

--- a/tests/test_verify_command.py
+++ b/tests/test_verify_command.py
@@ -295,3 +295,86 @@ class TestExitCodeContract:
             instance.run_halmos.return_value = fake_result
             result = runner.invoke(verify, [contract, "--tool", "halmos", "--quiet"])
             assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Economic invariant synthesis (--economic-invariants)
+# ---------------------------------------------------------------------------
+
+ERC4626_VAULT_SRC = """// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Vault {
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    function totalAssets() public view returns (uint256) {}
+    function convertToShares(uint256 a) public view returns (uint256) {}
+    function convertToAssets(uint256 s) public view returns (uint256) {}
+    function deposit(uint256 a, address r) public returns (uint256) {}
+    function withdraw(uint256 a, address r, address o) public returns (uint256) {}
+}
+"""
+
+
+@pytest.fixture
+def vault_contract(tmp_path):
+    p = tmp_path / "Vault.sol"
+    p.write_text(ERC4626_VAULT_SRC)
+    return str(p)
+
+
+class TestEconomicInvariantsFlag:
+    def test_help_lists_economic_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(verify, ["--help"])
+        assert result.exit_code == 0
+        assert "--economic-invariants" in result.output
+        assert "--invariants-out" in result.output
+
+    def test_economic_invariants_emitted_without_provers(self, vault_contract, tmp_path):
+        """Economic invariant synthesis must work with zero provers installed
+        (prover-independent path) and write CVL/Echidna/Foundry artifacts."""
+        out = tmp_path / "econ"
+        runner = CliRunner()
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            result = runner.invoke(
+                verify,
+                [
+                    vault_contract,
+                    "--economic-invariants",
+                    "--invariants-out",
+                    str(out),
+                    "--quiet",
+                ],
+            )
+        assert result.exit_code == 0
+        assert (out / "Vault.economic-invariants.json").exists()
+        assert (out / "Vault.economic.spec").exists()
+        assert (out / "Vault.economic.echidna.sol").exists()
+        assert (out / "Vault.economic.invariants.t.sol").exists()
+        cvl = (out / "Vault.economic.spec").read_text()
+        assert "vaultSolvency" in cvl
+
+    def test_economic_only_is_offline_no_ollama_required(self, vault_contract):
+        """No --invariants-out, no provers, no Ollama — must still succeed."""
+        runner = CliRunner()
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            with patch(
+                "miesc.adapters.invariant_synthesizer.InvariantSynthesizer._is_ollama_available",
+                return_value=False,
+            ):
+                result = runner.invoke(verify, [vault_contract, "--economic-invariants", "--quiet"])
+        assert result.exit_code == 0


### PR DESCRIPTION
Tier-2 of the v6.1 detection-gap work. WIRES the dormant `InvariantSynthesizer` (0 callers → live) into `miesc verify` and adds an economic invariant template library.

## What changed
- **dead → live**: `invariant_synthesizer.py` gains an `ECONOMIC` category + economic stage; `miesc verify` gains `--economic-invariants`/`--invariants-out`, emitting 4 artifacts (JSON + CVL .spec + Echidna .sol + Foundry .t.sol). Offline + prover-independent (works with zero provers/Ollama).
- **new template lib** `miesc/formal/economic_invariants.py`: `erc4626_share_price_non_decreasing`, `erc4626_first_deposit_guard`, `vault_solvency`, `no_withdraw_exceeds_deposit`, `total_supply_equals_sum_balances`, `price_not_from_spot_balance` (flash-loan resistance, honestly `auto_checkable=False`). Contract-type-aware selection.

## Honest scope
This **generates** the economic invariant artifacts (the input a Certora/Halmos/Echidna/Foundry run consumes) — it does **not** detect economic exploits end-to-end on its own, and does not auto-run the properties through a fuzzer (needs a harness). Generation is opt-in/gated → scan/audit untouched, no SmartBugs precision regression. Measured on a crafted vulnerable ERC-4626 vault: generated 5 economic invariants + all 4 artifacts.

## Verify
Full suite 9535 passed / 0 failed; ruff + black clean; `miesc verify --help` shows new flags. No frozen artifact touched.