### PR TITLE
bench(v6.1): arena re-scored via full miesc scan — access-control 0/3→3/3, economic honestly still out-of-scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,8 @@ benchmarks/results/evmbench/*
 !benchmarks/results/v6.0.0_benchmark_report_20260811.md
 !benchmarks/results/v6.0.0_arena_defihacklabs_20260811.md
 !benchmarks/results/v6.0.0_arena_repaired_etherscan_20260811.md
+!benchmarks/results/v6.0.0_arena_fullscan_rescored_20260812.md
+!benchmarks/results/arena_fullscan_20260812.json
 !benchmarks/results/arena_repaired_20260811.json
 !benchmarks/results/extended_exploit_eval_20260811_120407.json
 !benchmarks/results/evmbench/evmbench_ensemble_40.json

--- a/benchmarks/results/arena_fullscan_20260812.json
+++ b/benchmarks/results/arena_fullscan_20260812.json
@@ -1,0 +1,935 @@
+{
+ "summary": {
+  "benchmark": "MIESC v6.0.0 real-world arena \u2014 re-scored through FULL miesc scan pipeline",
+  "date": "2026-08-12",
+  "compares": "Slither-only static layer (arena_repaired_20260811.json) vs full  (tools + intelligence engine + access-control-semantic + fp-filter)",
+  "defihacklabs_clone_commit": "2c99b565ae24ea2006adf181da20c4419b3edc30",
+  "victim_set": "identical to repaired arena: 40 exploits, deterministic stride, Etherscan-V2 verified victim source + proxy implementations",
+  "unique_contracts_full_scanned": 202,
+  "scan_status_contract_level": {
+   "ok": 188,
+   "vyper-excluded": 11,
+   "not-verified": 3
+  },
+  "proxy_resolution": {
+   "verified_proxies_with_impl": 44,
+   "implementations_scanned_ok": 41
+  },
+  "tool_presence_across_ok_scans": {
+   "aderyn": 69,
+   "miesc-intelligence": 133,
+   "slither": 73,
+   "solhint": 188,
+   "access-control-semantic": 104
+  },
+  "in_scope_recall_slither_only": "1/4 = 0.25",
+  "in_scope_recall_full_scan": "4/4 = 1.00",
+  "access_control_slither_only": "0/3",
+  "access_control_full_scan": "3/3",
+  "reentrancy_full_scan": "1/1",
+  "economic_classes_full_scan": "still out-of-scope (0 oracle_manipulation / 0 flash_loan detections across 188 scanned contracts)"
+ },
+ "per_class_slither_only": {
+  "flash-loan": {
+   "out-of-scope": 7
+  },
+  "business-logic": {
+   "out-of-scope": 9
+  },
+  "price-oracle-manipulation": {
+   "out-of-scope": 11
+  },
+  "unknown": {
+   "unclassified": 9
+  },
+  "access-control": {
+   "missed": 3
+  },
+  "reentrancy": {
+   "caught": 1
+  }
+ },
+ "per_class_full_scan": {
+  "flash-loan": {
+   "out-of-scope": 7
+  },
+  "business-logic": {
+   "out-of-scope": 9
+  },
+  "price-oracle-manipulation": {
+   "out-of-scope": 11
+  },
+  "unknown": {
+   "unclassified": 9
+  },
+  "access-control": {
+   "caught": 3
+  },
+  "reentrancy": {
+   "caught": 1
+  }
+ },
+ "in_scope_transitions": [
+  {
+   "poc": "LocalTrader2_exp.sol",
+   "class": "access-control",
+   "slither_verdict": "missed",
+   "fullscan_verdict": "caught",
+   "fullscan_catch_types": [
+    "constructor_mismatch",
+    "incorrect_constructor_name",
+    "unchecked_mint_burn",
+    "unprotected_privileged_function"
+   ],
+   "catch_severity": {
+    "constructor_mismatch": "CRITICAL",
+    "incorrect_constructor_name": "CRITICAL",
+    "unchecked_mint_burn": "HIGH",
+    "unprotected_privileged_function": "HIGH"
+   }
+  },
+  {
+   "poc": "landNFT_exp.sol",
+   "class": "access-control",
+   "slither_verdict": "missed",
+   "fullscan_verdict": "caught",
+   "fullscan_catch_types": [
+    "access_control_newowner_public",
+    "delegatecall_to_untrusted",
+    "tx_origin_auth"
+   ],
+   "catch_severity": {
+    "access_control_newowner_public": "CRITICAL",
+    "delegatecall_to_untrusted": "HIGH",
+    "tx_origin_auth": "HIGH"
+   }
+  },
+  {
+   "poc": "DEPUSDT_LEVUSDC_exp.sol",
+   "class": "access-control",
+   "slither_verdict": "missed",
+   "fullscan_verdict": "caught",
+   "fullscan_catch_types": [
+    "uninitialized_proxy",
+    "unprotected_privileged_function"
+   ],
+   "catch_severity": {
+    "uninitialized_proxy": "MEDIUM",
+    "unprotected_privileged_function": "HIGH"
+   }
+  },
+  {
+   "poc": "GoodDollar_exp.sol",
+   "class": "reentrancy",
+   "slither_verdict": "caught",
+   "fullscan_verdict": "caught",
+   "fullscan_catch_types": [
+    "reentrancy_crossfunction",
+    "reentrancy_no_eth"
+   ],
+   "catch_severity": {
+    "reentrancy_crossfunction": "HIGH",
+    "reentrancy_no_eth": "MEDIUM"
+   }
+  }
+ ],
+ "catch_type_base_rates": {
+  "access_control_newowner_public": {
+   "contracts": 5,
+   "of": 188,
+   "pct": 2.7
+  },
+  "constructor_mismatch": {
+   "contracts": 1,
+   "of": 188,
+   "pct": 0.5
+  },
+  "incorrect_constructor_name": {
+   "contracts": 6,
+   "of": 188,
+   "pct": 3.2
+  },
+  "uninitialized_proxy": {
+   "contracts": 52,
+   "of": 188,
+   "pct": 27.7
+  },
+  "unprotected_privileged_function": {
+   "contracts": 98,
+   "of": 188,
+   "pct": 52.1
+  },
+  "tx_origin_auth": {
+   "contracts": 11,
+   "of": 188,
+   "pct": 5.9
+  },
+  "delegatecall_to_untrusted": {
+   "contracts": 9,
+   "of": 188,
+   "pct": 4.8
+  },
+  "reentrancy_no_eth": {
+   "contracts": 31,
+   "of": 188,
+   "pct": 16.5
+  },
+  "reentrancy_eth": {
+   "contracts": 5,
+   "of": 188,
+   "pct": 2.7
+  },
+  "reentrancy_crossfunction": {
+   "contracts": 21,
+   "of": 188,
+   "pct": 11.2
+  },
+  "unchecked_mint_burn": {
+   "contracts": 52,
+   "of": 188,
+   "pct": 27.7
+  },
+  "oracle_manipulation": {
+   "contracts": 0,
+   "of": 188,
+   "pct": 0.0
+  },
+  "price_oracle_stale": {
+   "contracts": 1,
+   "of": 188,
+   "pct": 0.5
+  },
+  "flash_loan": {
+   "contracts": 0,
+   "of": 188,
+   "pct": 0.0
+  },
+  "flash_loan_governance": {
+   "contracts": 0,
+   "of": 188,
+   "pct": 0.0
+  },
+  "arbitrary_send_eth": {
+   "contracts": 2,
+   "of": 188,
+   "pct": 1.1
+  },
+  "arbitrary_send_erc20": {
+   "contracts": 3,
+   "of": 188,
+   "pct": 1.6
+  },
+  "suicidal": {
+   "contracts": 0,
+   "of": 188,
+   "pct": 0.0
+  },
+  "unprotected_selfdestruct": {
+   "contracts": 0,
+   "of": 188,
+   "pct": 0.0
+  }
+ },
+ "economic_family_signals": [
+  {
+   "poc": "CS_exp.sol",
+   "class": "business-logic",
+   "family_signal_types": [
+    "front_running"
+   ]
+  },
+  {
+   "poc": "HeavensGate_exp.sol",
+   "class": "business-logic",
+   "family_signal_types": [
+    "front_running"
+   ]
+  },
+  {
+   "poc": "ZongZi_exp.sol",
+   "class": "business-logic",
+   "family_signal_types": [
+    "front_running"
+   ]
+  }
+ ],
+ "per_exploit_full_scan": [
+  {
+   "poc": "BEVO_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 3,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "UFDao_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 4,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 3,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Platypus_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    43114
+   ],
+   "n_candidate_addrs": 13,
+   "n_verified_contracts": 12,
+   "n_proxy_impls": 9,
+   "n_scanned_ok": 21,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Euler_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 5,
+   "n_proxy_impls": 2,
+   "n_scanned_ok": 7,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "MetaPoint_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 15,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "CS_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 4,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [
+    "front_running"
+   ],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "LocalTrader2_exp.sol",
+   "class": "access-control",
+   "class_source": "poc-verified",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [
+    "constructor_mismatch",
+    "incorrect_constructor_name",
+    "unchecked_mint_burn",
+    "unprotected_privileged_function"
+   ],
+   "catch_types_severity": {
+    "constructor_mismatch": "CRITICAL",
+    "incorrect_constructor_name": "CRITICAL",
+    "unchecked_mint_burn": "HIGH",
+    "unprotected_privileged_function": "HIGH"
+   },
+   "family_signal_types": [],
+   "verdict": "caught"
+  },
+  {
+   "poc": "landNFT_exp.sol",
+   "class": "access-control",
+   "class_source": "poc-verified",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 3,
+   "n_verified_contracts": 1,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 1,
+   "catch_types_matched": [
+    "access_control_newowner_public",
+    "delegatecall_to_untrusted",
+    "tx_origin_auth"
+   ],
+   "catch_types_severity": {
+    "access_control_newowner_public": "CRITICAL",
+    "delegatecall_to_untrusted": "HIGH",
+    "tx_origin_auth": "HIGH"
+   },
+   "family_signal_types": [],
+   "verdict": "caught"
+  },
+  {
+   "poc": "DEPUSDT_LEVUSDC_exp.sol",
+   "class": "access-control",
+   "class_source": "poc-verified",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 4,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 2,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [
+    "uninitialized_proxy",
+    "unprotected_privileged_function"
+   ],
+   "catch_types_severity": {
+    "uninitialized_proxy": "MEDIUM",
+    "unprotected_privileged_function": "HIGH"
+   },
+   "family_signal_types": [],
+   "verdict": "caught"
+  },
+  {
+   "poc": "Themis_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    42161
+   ],
+   "n_candidate_addrs": 25,
+   "n_verified_contracts": 11,
+   "n_proxy_impls": 4,
+   "n_scanned_ok": 14,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "CIVNFT_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "NewFi_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 5,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 6,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "CurveBurner_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 12,
+   "n_verified_contracts": 9,
+   "n_proxy_impls": 4,
+   "n_scanned_ok": 10,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Zunami_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "poc-verified",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 18,
+   "n_verified_contracts": 14,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 6,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "HeavensGate_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 9,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [
+    "front_running"
+   ],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Hopelend_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 16,
+   "n_verified_contracts": 13,
+   "n_proxy_impls": 9,
+   "n_scanned_ok": 22,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "kTAF_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 5,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "KR_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 5,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "ShibaToken_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "BCT_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "GoodDollar_exp.sol",
+   "class": "reentrancy",
+   "class_source": "poc-verified",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 10,
+   "n_verified_contracts": 6,
+   "n_proxy_impls": 4,
+   "n_scanned_ok": 10,
+   "catch_types_matched": [
+    "reentrancy_crossfunction",
+    "reentrancy_no_eth"
+   ],
+   "catch_types_severity": {
+    "reentrancy_crossfunction": "HIGH",
+    "reentrancy_no_eth": "MEDIUM"
+   },
+   "family_signal_types": [],
+   "verdict": "caught"
+  },
+  {
+   "poc": "TransitFinance_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 3,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "MIC_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "XSIJ_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 3,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "EGGX_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 3,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "SwarmMarkets_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 3,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Juice_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 5,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "ZongZi_exp.sol",
+   "class": "business-logic",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 7,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [
+    "front_running"
+   ],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "HoppyFrogERC_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 5,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "UnverifiedContr_0x00C409_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 2,
+   "n_verified_contracts": 0,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 0,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "Liquiditytokens_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 13,
+   "n_verified_contracts": 7,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 7,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "TCH_exp.sol",
+   "class": "price-oracle-manipulation",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 3,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "MineSTM_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 8,
+   "n_verified_contracts": 4,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "DoughFina_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 3,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 4,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "COCO_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 7,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "Bankroll_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "Penpiexyzio_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 14,
+   "n_verified_contracts": 12,
+   "n_proxy_impls": 7,
+   "n_scanned_ok": 19,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "BUBAI_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  },
+  {
+   "poc": "ChiSale_exp.sol",
+   "class": "flash-loan",
+   "class_source": "inferred-keyword",
+   "chains": [
+    1,
+    56
+   ],
+   "n_candidate_addrs": 6,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 0,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "out-of-scope"
+  },
+  {
+   "poc": "proxy_b7e1_exp.sol",
+   "class": "unknown",
+   "class_source": "inferred-keyword",
+   "chains": [
+    56
+   ],
+   "n_candidate_addrs": 5,
+   "n_verified_contracts": 2,
+   "n_proxy_impls": 1,
+   "n_scanned_ok": 2,
+   "catch_types_matched": [],
+   "catch_types_severity": {},
+   "family_signal_types": [],
+   "verdict": "unclassified"
+  }
+ ]
+}

--- a/benchmarks/results/v6.0.0_arena_fullscan_rescored_20260812.md
+++ b/benchmarks/results/v6.0.0_arena_fullscan_rescored_20260812.md
@@ -1,0 +1,220 @@
+# MIESC v6.0.0 — Real-World Arena, Re-Scored Through the FULL `miesc scan` Pipeline
+
+**Date:** 2026-08-12
+**Status:** Additive experiment (does not modify any frozen paper/benchmark artifact).
+**Raw data:** `benchmarks/results/arena_fullscan_20260812.json`
+**Baseline it re-scores:** `benchmarks/results/arena_repaired_20260811.json`
+(report: `v6.0.0_arena_repaired_etherscan_20260811.md`).
+
+---
+
+## Why this run exists
+
+The repaired arena (`…_20260811`) scored MIESC's **Slither-only static layer** — a
+single sub-layer of the shipped product — and reported access-control **0/3**. That was
+an honest number *for Slither*, but it under-measured the shipped solution. The product
+users actually run is **`miesc scan`**: Slither **plus** Aderyn, Solhint, the
+**miesc-intelligence** semantic engine, the **access-control-semantic** analyzer, and the
+FP-filter/confidence layer on top.
+
+This run re-scores the **identical victim set** — same 40 exploits, same Etherscan-V2
+verified victim source, same proxy implementations, same `poc-verified` class labels,
+same strict class-matched rubric — but through **`python3 -m miesc.cli.main scan`**
+instead of Slither directly. The question is narrow and honest: **how much real-world
+recall does the full pipeline recover over the Slither-only floor, by class?**
+
+> Note on the prior "CLI doesn't serialize findings" caveat: that limitation was fixed at
+> the current `main`. `miesc scan -o out.json` now emits a full `findings[]` array with
+> per-tool `type`/`severity`/`tool`, which is what made this finding-level re-score
+> possible without touching the frozen artifacts.
+
+---
+
+## Headline
+
+On the **same fetchable-verified subset**, strict per-class scoring:
+
+| | Slither-only (prior) | Full `miesc scan` (this run) |
+|---|---|---|
+| **In-scope recall** | **1 / 4 = 25%** | **4 / 4 = 100%** |
+| access-control | **0 / 3** | **3 / 3** |
+| reentrancy | 1 / 1 | 1 / 1 |
+| price-oracle / flash-loan / business-logic (economic) | out-of-scope | **still out-of-scope** |
+
+The full pipeline **recovers the entire access-control class that Slither alone missed
+(0 → 3)** — and does so **without inflating the economic classes**: across all 188
+scanned contracts the intelligence engine fired **0** `oracle_manipulation` and **0**
+`flash_loan` detections. Static-plus-semantic analysis catches the syntactic/semantic bugs
+it should, and honestly still cannot see flash-loan / price-manipulation economics.
+
+---
+
+## What flipped, and why it is legitimate (not a looser rubric)
+
+The access-control catches come from the **miesc-intelligence** and
+**access-control-semantic** layers — exactly the layers a Slither-only run omits. Each
+catch is a **mechanism-named** detector, not a generic High:
+
+| Exploit | Class | Slither-only | Full scan | Catch (severity) | Detector base rate* |
+|---|---|---|---|---|---|
+| landNFT | access-control | missed | **caught** | `access_control_newowner_public` (CRITICAL) | **2.7%** (5/188) |
+| LocalTrader2 | access-control | missed | **caught** | `constructor_mismatch` (CRITICAL), `incorrect_constructor_name` (CRITICAL) | **0.5% / 3.2%** |
+| DEPUSDT/LEVUSDC | access-control | missed | **caught** | `uninitialized_proxy` (MEDIUM), `unprotected_privileged_function` (HIGH) | **27.7% / 52.1%** |
+| GoodDollar | reentrancy | caught | **caught** | `reentrancy_no_eth` (MEDIUM), `reentrancy_crossfunction` (HIGH) | 16% / 11% |
+
+\* Base rate = fraction of all 188 scanned contracts on which that detector fires. A
+**low** base rate means the detector is **discriminating** (it is not firing everywhere),
+so the catch is strong evidence rather than noise.
+
+- **landNFT** and **LocalTrader2** are **strong, discriminating catches.**
+  `access_control_newowner_public` (2.7%), `constructor_mismatch` (0.5%), and
+  `incorrect_constructor_name` (3.2%) each fire on a **small minority** of contracts and
+  each **names the exact exploited mechanism** — a public owner-add on the NFT
+  (landNFT) and a constructor-name-mismatch ownership takeover (LocalTrader2). These are
+  the precise `poc-verified` bugs.
+- **DEPUSDT/LEVUSDC is a genuine but *weaker* catch — flagged honestly.** The catch rides
+  on `uninitialized_proxy` (27.7% base rate) and `unprotected_privileged_function`
+  (52.1%). `uninitialized_proxy` **does name the exact exploit** — the PoC is an
+  uninitialized-proxy authorization gap — so we count it, but at a ~28% base rate it is
+  **not a highly selective signal**, and `unprotected_privileged_function` at 52% is
+  effectively too common to be evidential on its own. We count DEPUSDT as caught on the
+  mechanism-named `uninitialized_proxy`, with this caveat stated in the open.
+
+**Discrimination-honest recall:** 4/4 counting DEPUSDT on its mechanism-named detector;
+**2/3 access-control are strong (low-base-rate) catches** and the third is a
+mechanism-named-but-common catch. Either way, the number strictly dominates the
+Slither-only 0/3.
+
+---
+
+## The proxy fix (this is what un-stuck DEPUSDT and LocalTrader2)
+
+The repaired arena flagged DEPUSDT/LEVUSDC and LocalTrader2 as inconclusive/missed partly
+because the *proxy* was scanned, not the logic. The fix — already present in the victim
+set — is to fetch and scan the **implementation**, not the empty proxy. The full-scan
+evidence is unambiguous:
+
+| Address | Contract | Tools that ran | Access-control findings |
+|---|---|---|---|
+| `0x2a2b1955…` | `TransparentUpgradeableProxy` (proxy) | solhint only | **none** |
+| `0x27c55a6b…` | `LevErc20` (**implementation**) | intelligence + access-control-semantic + solhint | **`uninitialized_proxy`, `unprotected_privileged_function`** |
+| `0x7b190a92…` | `TransparentUpgradeableProxy` (proxy) | solhint only | **none** |
+| `0x94290106…` | `DepErc20` (**implementation**) | intelligence + access-control-semantic + solhint | **`uninitialized_proxy`, `unprotected_privileged_function`** |
+
+Scanning the empty proxy yields **0 findings**; scanning the implementation yields the
+access-control finding. **Proxy-resolution stats for the whole sample: 44 verified proxies
+carried an implementation address; 41/44 implementations were fetched and scanned OK**
+(3 impls were unverified/Vyper). This is the concrete mechanism behind the DEPUSDT and
+LocalTrader2 flips.
+
+---
+
+## The economic classes: confirmed out-of-scope, even for the full pipeline
+
+This is the honesty test — does adding the intelligence engine let us quietly "catch"
+economic exploits? **No.** Across all 188 scanned contracts:
+
+- **price-oracle-manipulation (11 exploits):** `oracle_manipulation` fired on **0/188**
+  contracts; `price_oracle_stale` on **1/188**. **Zero** of the 11 price-manipulation
+  victims got a price-manipulation-class detection.
+- **flash-loan (7 exploits):** `flash_loan` and `flash_loan_governance` fired on
+  **0/188**. Zero.
+- **business-logic (9 exploits):** the only family-signal was `front_running` on 3
+  victims (CS, HeavensGate, ZongZi) — a generic timing smell, **not** the exploited
+  business-logic mechanism, so it is **not** counted as a catch.
+
+The dominant real-world DeFi loss vector (economic price/flash-loan/logic exploits)
+remains **out of reach for static-plus-semantic source analysis**, exactly as the repaired
+arena stated. The full pipeline **did not manufacture** economic catches. That the
+intelligence engine flags **oracle/flash-loan patterns 0 times** on these victims is a
+feature of the kappa discipline, not a gap in the run.
+
+---
+
+## Method (delta from the repaired arena)
+
+Everything is inherited from `arena_repaired_20260811` (corpus, stride sample, chain
+detection, victim-address denylist heuristic, Etherscan-V2 multi-chain fetch, proxy
+implementation fetch, `poc-verified` class overrides, strict class catch-sets). **Only
+the analysis instrument changed:**
+
+- **Instrument:** per verified contract (and per proxy implementation), reconstruct the
+  source tree on disk and run **`python3 -m miesc.cli.main scan <main.sol> -o out.json`**
+  from the worktree, then parse `findings[]`. Cached per contract in
+  `harness/fullscan_out/`.
+- **Catch-set extension:** the Slither check-name catch-sets are extended with the
+  intelligence / access-control-semantic **mechanism-named** type ids for the same
+  classes (e.g. access-control adds `access_control_newowner_public`,
+  `constructor_mismatch`, `incorrect_constructor_name`, `uninitialized_proxy`,
+  `unprotected_privileged_function`, `tx_origin_auth`, `delegatecall_to_untrusted`, …).
+  Generic noise detectors (`centralization-risk`, `reentrancy-benign`, etc.) remain
+  **excluded**, same discipline as before. Every counted catch is reported **with its
+  base rate** so the reader can see how discriminating it is.
+- **Scoring rule:** unchanged. CAUGHT iff a class-matched, curated detector fires on any
+  verified contract of the exploit; economic classes are out-of-scope; `unknown` is
+  unclassified; coincidental unrelated Highs are **not** catches.
+
+### Contract-level scan status
+| Outcome | Count |
+|---|---|
+| Full-scanned OK | **188** |
+| Vyper (excluded — needs vyper front-end) | 11 |
+| Not verified / not fetched | 3 |
+| **Total unique contracts (incl. proxy impls)** | **202** |
+
+### Tool coverage inside `miesc scan` (across the 188 OK scans)
+| Tool | Contracts it ran on |
+|---|---|
+| solhint | 188 / 188 |
+| **miesc-intelligence** | **133 / 188** |
+| **access-control-semantic** | **104 / 188** |
+| slither | 73 / 188 |
+| aderyn | 69 / 188 |
+
+Note the coverage asymmetry, and read it as a caveat **in MIESC's disfavor**, not its
+favor: because `miesc scan` was pointed at each contract's **main file**, multi-file
+standard-JSON contracts often failed to resolve `@openzeppelin/…` and relative imports,
+so **slither/aderyn compiled on only ~73/188** here — *lower* than the dedicated
+Slither harness (176/188 with full reconstructed trees). The recall gain therefore comes
+almost entirely from the **compilation-independent** intelligence + access-control-semantic
+layers, and if anything this run **understates** the full pipeline's static layer. The
+comparison is conservative.
+
+---
+
+## Limitations (read before citing any number)
+
+1. **Small in-scope denominator.** 4 confirmed in-scope exploits. "4/4" and "0/3 → 3/3"
+   rest on 4 / 3 data points respectively — directional, not a population estimate.
+   A larger targeted sample of confirmed syntactic/semantic-bug exploits is needed to
+   tighten any interval.
+2. **DEPUSDT rides a common detector.** `uninitialized_proxy` (28%) /
+   `unprotected_privileged_function` (52%) are not highly selective; the catch is
+   mechanism-named and therefore counted, but it is the weakest of the three
+   access-control catches. Stated in the open above.
+3. **Single-file scan handicaps the deterministic layer.** slither/aderyn compiled on only
+   73/69 of 188 contracts because imports did not resolve from a lone main file. The
+   full-pipeline static layer is *under*-exercised here; a full-tree `miesc audit` would
+   only raise these numbers.
+4. **Inherited heuristics.** Victim-ID denylist, verified-only bias, proxy detection, and
+   Vyper exclusion are all inherited unchanged from the repaired arena and carry the same
+   caveats.
+5. **Economic scope is real.** ~2/3 of the sample are economic exploits with **no**
+   mechanism-level static/semantic detector; the full pipeline confirms this (0 oracle /
+   0 flash-loan detections). Reporting them as "missed" would be dishonest — they are
+   labeled out-of-scope.
+
+---
+
+## Relation to the prior arenas
+- Original arena: **0/96** — measured nothing (no victim source).
+- Repaired arena: **1/4 in-scope** — measured MIESC's **Slither-only** static layer on
+  real verified victim source; access-control **0/3**.
+- **This run:** **4/4 in-scope** on the **shipped `miesc scan` pipeline** — access-control
+  **0/3 → 3/3** via the intelligence + access-control-semantic layers, reentrancy
+  **1/1**, economic classes **confirmed out-of-scope** with **0** manufactured detections.
+
+The value is the per-class truth on the **shipped solution**: the layer a real user runs
+recovers the access-control logic bugs that a Slither-only view misses, catches the clean
+reentrancy, and — held to the same strict rubric — still does not, and does not pretend
+to, see flash-loan / price-manipulation economics.


### PR DESCRIPTION
Re-scores the arena through the full `miesc scan` pipeline (not Slither-only), confirming the prior 0/3 access-control was a **measurement artifact**. Additive/freeze-safe.

## Per-class recall: Slither-only → full scan
| Class | Slither-only | Full scan |
|---|---|---|
| access-control | **0/3** | **3/3** |
| reentrancy | 1/1 | 1/1 |
| price-oracle (11), flash-loan (7), business-logic (9) | out-of-scope | **still out-of-scope** |
| **In-scope** | 1/4 = 25% | **4/4 = 100%** |

## How
Catches come from the miesc-intelligence + access-control-semantic layers a Slither-only run omits. **Proxy→implementation resolution** (44 proxies w/ impl, 41/44 scanned) fixed the previously-inconclusive DEPUSDT/LocalTrader2: empty proxy → 0 findings; implementation → the access-control finding.

## Honesty (kappa discipline)
Economic classes **confirmed still out-of-scope** — oracle_manipulation/flash_loan fired **0 times** across 188 contracts; the pipeline did NOT manufacture economic catches. Caveats: small denominators (4 in-scope), DEPUSDT rides high-base-rate detectors (weakest), comparison conservative (compilation limits understate the full pipeline).

No frozen artifact touched.