### PR TITLE
fix(security): safe_parse_llm_json fail-open on invalid LLM output

### DIFF
--- a/miesc/security/llm_output_validator.py
+++ b/miesc/security/llm_output_validator.py
@@ -490,16 +490,21 @@ def safe_parse_llm_json(
                 raw_content=content,
             )
 
-        # Try lenient parsing - extract what we can
+        # Lenient mode: surface a best-effort partial object for inspection, but the
+        # result is NOT valid. ``model_construct`` bypasses every validator, type check
+        # and sanitizer, so returning ``is_valid=True`` here would fail OPEN — malformed
+        # or malicious LLM output would flow downstream as if it had been validated.
+        # Callers MUST check ``is_valid`` before trusting ``data``.
         logger.warning(f"Validation errors (lenient mode): {error_messages}")
         warnings.extend(error_messages)
 
         try:
-            # Use model_construct for partial data
+            # Best-effort, UNVALIDATED partial data — for inspection only.
             partial = model_class.model_construct(**data)
             return ValidationResult(
-                is_valid=True,
+                is_valid=False,
                 data=partial,
+                errors=error_messages,
                 warnings=warnings,
                 raw_content=content,
             )

--- a/tests/test_llm_output_validator.py
+++ b/tests/test_llm_output_validator.py
@@ -513,13 +513,38 @@ End of report."""
         result = safe_parse_llm_json(content, AnalysisResponse, strict=True)
         assert result.is_valid is False
 
-    def test_lenient_mode_partial(self):
-        """Test lenient mode creates partial data."""
-        # Missing required fields but has some data
-        content = '{"summary": "Test summary"}'
+    def test_lenient_mode_partial_data_is_not_valid(self):
+        """Lenient mode returns best-effort partial data, but is_valid is False.
+
+        ``model_construct`` bypasses every validator, so the data did NOT pass
+        validation; marking it valid would fail open. The partial data and the
+        validation errors are both surfaced for the caller to inspect.
+        """
+        content = '{"summary": "Test summary"}'  # missing required fields
         result = safe_parse_llm_json(content, AnalysisResponse, strict=False)
-        # Should succeed in lenient mode
-        assert result.is_valid is True
+        assert result.is_valid is False
+        assert result.data is not None  # partial still available for inspection
+        assert result.errors  # the validation errors are surfaced
+
+    def test_lenient_mode_does_not_fail_open_on_malicious_output(self):
+        """Security regression: invalid/malicious LLM output must never come back as
+        valid in the default (lenient) mode — otherwise unvalidated, unsanitized data
+        would flow downstream as if it had been checked."""
+        # A field that violates the schema (out-of-range / wrong type) must not pass.
+        content = '{"summary": "x", "risk_score": 9999, "vulnerabilities": "NOT_A_LIST"}'
+        result = safe_parse_llm_json(content, AnalysisResponse, strict=False)
+        assert result.is_valid is False, "invalid LLM output must not be reported valid"
+
+    def test_lenient_mode_invalid_partial_is_not_trusted(self):
+        """Lenient mode may expose partial data, but must not fail open as valid."""
+        content = '{"vulnerabilities": "not_an_array", "summary": "Test summary"}'
+
+        result = safe_parse_llm_json(content, AnalysisResponse, strict=False)
+
+        assert result.is_valid is False
+        assert result.data is not None
+        assert result.errors
+        assert result.warnings
 
 
 class TestValidateVulnerabilityFinding:

--- a/tests/test_llm_output_validator.py
+++ b/tests/test_llm_output_validator.py
@@ -513,27 +513,26 @@ End of report."""
         result = safe_parse_llm_json(content, AnalysisResponse, strict=True)
         assert result.is_valid is False
 
-    def test_lenient_mode_partial_data_is_not_valid(self):
-        """Lenient mode returns best-effort partial data, but is_valid is False.
-
-        ``model_construct`` bypasses every validator, so the data did NOT pass
-        validation; marking it valid would fail open. The partial data and the
-        validation errors are both surfaced for the caller to inspect.
-        """
-        content = '{"summary": "Test summary"}'  # missing required fields
+    def test_lenient_mode_partial(self):
+        """A minimal-but-schema-valid input succeeds in lenient mode."""
+        # AnalysisResponse fills defaults, so this is actually valid.
+        content = '{"summary": "Test summary"}'
         result = safe_parse_llm_json(content, AnalysisResponse, strict=False)
-        assert result.is_valid is False
-        assert result.data is not None  # partial still available for inspection
-        assert result.errors  # the validation errors are surfaced
+        assert result.is_valid is True
 
-    def test_lenient_mode_does_not_fail_open_on_malicious_output(self):
-        """Security regression: invalid/malicious LLM output must never come back as
-        valid in the default (lenient) mode — otherwise unvalidated, unsanitized data
-        would flow downstream as if it had been checked."""
-        # A field that violates the schema (out-of-range / wrong type) must not pass.
+    def test_lenient_mode_does_not_fail_open_on_invalid_output(self):
+        """Security regression: LLM output that violates the schema must NOT come back
+        as valid in the default (lenient) mode. ``model_construct`` bypasses every
+        validator, so returning ``is_valid=True`` would let unvalidated, unsanitized
+        data flow downstream as if it had been checked (fail-open). The partial data
+        and the errors are still surfaced for inspection, but ``is_valid`` is False.
+        """
+        # risk_score out of range AND vulnerabilities is the wrong type -> invalid.
         content = '{"summary": "x", "risk_score": 9999, "vulnerabilities": "NOT_A_LIST"}'
         result = safe_parse_llm_json(content, AnalysisResponse, strict=False)
         assert result.is_valid is False, "invalid LLM output must not be reported valid"
+        assert result.data is not None  # partial still available for inspection
+        assert result.errors  # the validation errors are surfaced
 
     def test_lenient_mode_invalid_partial_is_not_trusted(self):
         """Lenient mode may expose partial data, but must not fail open as valid."""


### PR DESCRIPTION
From a proactive security audit of MIESC's own defensive modules.

## The defect (HIGH)
`safe_parse_llm_json` in the **default (lenient) mode**: when pydantic validation failed, it called `model_construct(**data)` — which **bypasses every validator, type check and sanitizer** — and returned `is_valid=True`. So invalid or malicious LLM output (e.g. `risk_score: 9999`, `vulnerabilities: "NOT_A_LIST"`, injected `type="<script>…"`) was reported as **validated**, defeating the module's whole purpose ("reject malformed outputs; MUST be validated before use").

## Fix
In lenient mode, the best-effort partial object is still returned **for inspection**, but `is_valid` is now **False** and the validation `errors` are surfaced. The main consumer, `llm_orchestrator.py` (`if validation_result.is_valid and …`), already gates on `is_valid`, so this makes it **fail-closed** — invalid output is no longer trusted.

## Tests / safety
Updated `test_lenient_mode_partial` (its input is actually schema-valid) + new `test_lenient_mode_does_not_fail_open_on_invalid_output` (schema-violating input → `is_valid=False`, data+errors still present). 83 validator tests pass; ruff+black clean. No frozen artifacts.

**Follow-up (separate):** `smartllm_adapter.py` consumes the result without checking `is_valid` and does attribute access on raw dicts — it should gate on `is_valid` too. Flagged, not in this PR.

Found by verifying the audit finding against the real code (I re-read the block myself; the concurrent-safe deliverable was the report — this is the opt-in fix for the HIGH item).