### PR TITLE
fix(adapters): stop Mythril cross-validation crashing on null swc_id

### DIFF
--- a/miesc/adapters/mythril_adapter.py
+++ b/miesc/adapters/mythril_adapter.py
@@ -590,7 +590,10 @@ class MythrilAdapter(ToolAdapter):
 
             # Find matching Mythril finding
             for mythril_finding in result.get("findings", []):
-                swc = mythril_finding.get("swc_id", "").replace("SWC-", "")
+                # ``swc_id`` is normalized to ``None`` (not "") when Mythril emits
+                # an issue without an SWC id, so ``.get(..., "")`` still yields None
+                # for a present-but-None key. Coerce with ``or ""`` before .replace.
+                swc = (mythril_finding.get("swc_id") or "").replace("SWC-", "")
                 if swc in expected_swcs:
                     return True, mythril_finding
 

--- a/tests/test_mythril_validate_swc.py
+++ b/tests/test_mythril_validate_swc.py
@@ -1,0 +1,64 @@
+"""Regression tests for MythrilAdapter.validate_finding SWC-id handling.
+
+Mythril legitimately emits issues without an ``swc-id`` for several detectors.
+``normalize_findings`` stores that as ``swc_id: None`` (not ``""``), so a
+``.get("swc_id", "")`` on a present-but-None key still yields ``None``. Calling
+``.replace(...)`` on that value used to raise ``AttributeError`` and crash the
+whole cross-validation run (fail-hard on hostile/atypical tool output).
+"""
+
+from unittest.mock import MagicMock
+
+from miesc.adapters.mythril_adapter import MythrilAdapter
+
+
+def _adapter_returning(findings):
+    """Build a MythrilAdapter whose analyze() yields the given findings."""
+    adapter = MythrilAdapter()
+    adapter.analyze = MagicMock(return_value={"status": "success", "findings": findings})
+    return adapter
+
+
+def test_validate_finding_survives_none_swc_id():
+    """A Mythril finding with swc_id=None must not crash validate_finding."""
+    adapter = _adapter_returning([{"swc_id": None, "title": "Some issue"}])
+
+    # Must return a (bool, finding_or_None) tuple, never raise AttributeError.
+    confirmed, match = adapter.validate_finding(
+        source_code="contract C {}",
+        finding_type="reentrancy",
+        finding_line=1,
+    )
+    assert confirmed is False
+    assert match is None
+
+
+def test_validate_finding_matches_normal_swc_id():
+    """The normal path (swc_id present) still confirms a matching finding."""
+    adapter = _adapter_returning([{"swc_id": "SWC-107", "title": "Reentrancy"}])
+
+    confirmed, match = adapter.validate_finding(
+        source_code="contract C {}",
+        finding_type="reentrancy",
+        finding_line=1,
+    )
+    assert confirmed is True
+    assert match is not None
+
+
+def test_validate_finding_mixed_none_and_real_swc():
+    """A None swc_id ahead of a real match must not short-circuit the loop."""
+    adapter = _adapter_returning(
+        [
+            {"swc_id": None, "title": "Unclassified"},
+            {"swc_id": "SWC-107", "title": "Reentrancy"},
+        ]
+    )
+
+    confirmed, match = adapter.validate_finding(
+        source_code="contract C {}",
+        finding_type="reentrancy",
+        finding_line=1,
+    )
+    assert confirmed is True
+    assert match["swc_id"] == "SWC-107"


### PR DESCRIPTION
## Problem

`MythrilAdapter.validate_finding` crashes with `AttributeError` when Mythril emits an issue **without** an SWC id.

Mythril legitimately omits `swc-id` for several detectors. `normalize_findings` stores that as `swc_id: None` (not `""`). In the cross-validation loop:

```python
swc = mythril_finding.get("swc_id", "").replace("SWC-", "")
```

the key is **present** with value `None`, so the `""` default never applies — `None.replace(...)` raises. The call sits in a `try/finally` with **no** `except`, so the exception propagates through `validate_findings_with_mythril` and aborts the whole run. A scan crashing on a tool's own atypical-but-valid output is a fail-hard defect (found via an adversarial audit of untrusted-output parsing).

## Fix

Coerce `None` → `""` before `.replace`:

```python
swc = (mythril_finding.get("swc_id") or "").replace("SWC-", "")
```

## Tests

New `tests/test_mythril_validate_swc.py` — 3 regression cases (null swc_id, normal match, mixed null-then-real). Without the fix the null case raises `AttributeError`; with it, all pass. ruff + black clean.