### PR TITLE
docs(dpga): add filing readiness checkpoint

### DIFF
--- a/docs/dpga/DPGA_FILING_READINESS_20260819.md
+++ b/docs/dpga/DPGA_FILING_READINESS_20260819.md
@@ -1,0 +1,70 @@
+# MIESC DPGA Filing Readiness - 2026-08-19
+
+This checkpoint records the DPGA submission state after the August 2026
+integration pass. It is additive filing support: it does not replace
+`docs/dpga/DPGA_SUBMISSION.md` or `docs/policies/DPG-COMPLIANCE.md`, and it does
+not modify frozen paper, benchmark, or claims artifacts.
+
+## Repository State
+
+| Item | Status | Evidence |
+|---|---|---|
+| Default branch | Ready for filing snapshot | `origin/main` at `f5a800c4` |
+| Latest merged fix | Integrated | PR #125, `fix(adapters): stop Mythril cross-validation crashing on null swc_id` |
+| DPGA submission package | Present | `docs/dpga/DPGA_SUBMISSION.md` |
+| DPG compliance statement | Present | `docs/policies/DPG-COMPLIANCE.md` |
+| Hosted documentation | Live | `https://fboiero.github.io/MIESC/` returned HTTP 200 on 2026-08-19 |
+| Open MIESC PRs | None observed | `gh pr list --state open` returned an empty list |
+
+## Recent Integration Closures
+
+| PR | Status | Why it matters for filing |
+|---|---|---|
+| #125 | Merged 2026-08-19 04:15 UTC | Removes a Mythril adapter crash on `null` SWC ids, improving robustness of symbolic-execution evidence. |
+| #124 | Merged 2026-08-18 15:56 UTC | Removes the dead quick-scanner module after scan-path consolidation. |
+| #123 | Merged 2026-08-18 15:45 UTC | Fails closed on invalid LLM output instead of accepting unsafe partial parses. |
+| #122 | Merged 2026-08-18 15:36 UTC | Python dependency hygiene. |
+| #121 | Merged 2026-08-18 15:36 UTC | Changelog action hygiene. |
+| #120 | Merged 2026-08-18 15:36 UTC | CodeQL action hygiene. |
+| #119 | Merged 2026-08-18 15:36 UTC | Adds full `miesc scan` arena re-score evidence without overwriting frozen benchmark artifacts. |
+| #118 | Merged 2026-08-18 15:36 UTC | Adds economic invariant wiring and ERC4626/solvency templates. |
+| #117 | Merged 2026-08-18 15:36 UTC | Documents the arena methodology finding that access-control was under-measured by Slither-only scoring. |
+
+## CI Status
+
+At the time of this checkpoint, the post-merge workflows for `origin/main`
+triggered by PR #125 were partially complete:
+
+| Workflow | Observed status |
+|---|---|
+| MIESC Security Audit | success |
+| OpenSSF Scorecard | success |
+| MIESC CI/CD Pipeline | in progress |
+| Documentation | in progress |
+| Research Evaluation | in progress |
+| Docker Build and Publish | in progress |
+
+Filing recommendation: do not state "all latest CI is green" until the four
+in-progress workflows complete successfully. It is accurate to state that the
+repository has no open PRs and that the hosted documentation endpoint is live.
+
+## Filing Checklist Delta
+
+- Application id and GID still need portal confirmation before final submission:
+  `#13478` and `GID0092948` are carried from existing DPGA records.
+- Hosted docs were reachable on 2026-08-19 with HTTP 200 and a MkDocs page title
+  for MIESC.
+- Keep the current self-assessment framing: "self-assessed 9/9 indicators met,
+  DPGA review under way" unless the DPGA portal shows a decided status.
+- Use `docs/dpga/DPGA_SUBMISSION.md` as the reviewer-facing index and this file
+  as the dated readiness delta.
+- Refresh the CI row after the pending post-merge workflows finish.
+
+## Non-Blocking Local Notes
+
+- `MIESC-main` was on `docs/dpga-filing-ready`, tracking `origin/main`, with only
+  the longstanding untracked `benchmarks/smartbugs_fp_filter_effect_20260710.py`.
+- `MIESC-secfix-validator` remained locally divergent after PR #123 was merged;
+  this does not affect the default branch filing snapshot.
+- The frozen paper worktree still contains unrelated untracked paper build
+  outputs and was not touched.

--- a/docs/dpga/DPGA_SUBMISSION.md
+++ b/docs/dpga/DPGA_SUBMISSION.md
@@ -164,15 +164,22 @@ Standard version cited (v1.1.6) is current (published 2024-09-04).
 | 5 | Documentation | Evidence VERIFIED ✓ | README EN/ES, `CONTRIBUTING.md`, `openapi.yaml` all resolve. Reconfirm the hosted site (`fboiero.github.io/MIESC`) renders live before filing — it could not be checked from the repo. |
 | 6 | Data extraction / portability | Evidence VERIFIED ✓ | Open export formats (JSON, SARIF 2.1, CSV, Markdown, HTML, PDF) documented in `DPG-COMPLIANCE.md` §6. |
 | 7 | Privacy & applicable laws | Evidence VERIFIED ✓ | `PRIVACY.md` present; local processing, no telemetry; GDPR/CCPA/Argentina Law 25.326 noted. |
-| 8 | Standards & best practices | Evidence VERIFIED ✓ | SARIF/OpenAPI/MCP/SWC/CWE + 12 standards + Contributor Covenant CoC. Security-scanner list corrected to match `ci.yml` (Bandit, pip-audit, safety, Trivy, CodeQL — Semgrep/Snyk were not actually wired in). The point-in-time test count in §8 should be re-run and refreshed against v6.0.0 before it is quoted to a reviewer. |
+| 8 | Standards & best practices | Evidence VERIFIED ✓ | SARIF/OpenAPI/MCP/SWC/CWE + 12 standards + Contributor Covenant CoC. Security-scanner list matches `ci.yml` (Bandit, pip-audit, safety, Trivy, CodeQL — Semgrep/Snyk were never wired in and are not claimed). Coverage/mutation figures in §8 reconciled to the release-validation record (`POST_RELEASE_VALIDATION_2026-07-13.md`): **81% line coverage** (was overstated as 88%), 75% mutation on core v6 modules. The 9130-test figure is a point-in-time local regression — re-run and refresh before quoting a fresh count. |
 | 9 | Do no harm by design | Evidence VERIFIED ✓ | `DO_NO_HARM.md` + `RESPONSIBLE_USE.md` + dual-use narrative; 9A/9B/9C answers in the responses CSV (no PII, no hosted content, CoC governs interactions). |
 
 **Bottom line.** All nine indicators resolve to real, current in-repo evidence;
-no broken links remain in this package or in `DPG-COMPLIANCE.md` (EN/ES). The
-verdict is a self-assessment supporting the DPGA's open review of application
-#13478 — it does not assert the DPGA has granted recognition. Two residual items
-are reviewer-facing rather than blocking: confirm the hosted docs site is live
-(indicator 5) and refresh the test count against v6.0.0 (indicator 8).
+no broken links remain in this package or in `DPG-COMPLIANCE.md` (EN/ES). During
+this filing-readiness pass, three broken evidence links in
+`DPGA_Application_Responses.csv` were corrected to their canonical `docs/` paths
+(`DPG-COMPLIANCE.md`, `CONTRIBUTORS.md`, `PRIVACY.md` live under `docs/` /
+`docs/policies/`, not the repository root), the stale Docker tag in that CSV was
+updated to `6.0.0`, and the line-coverage figure was reconciled from an
+overstated 88% down to the release-validated **81%**. The verdict is a
+self-assessment supporting the DPGA's open review of application #13478 — it does
+not assert the DPGA has granted recognition. Two residual items are
+reviewer-facing rather than blocking: confirm the hosted docs site is live
+(indicator 5) and re-run the suite to refresh the point-in-time test count
+against v6.0.0 (indicator 8).
 
 **Flagged in frozen files (not editable in this pass — for Fernando's attention).**
 The root `README.md` (a frozen paper artifact) states the project "is fully

--- a/docs/policies/DPG-COMPLIANCE.md
+++ b/docs/policies/DPG-COMPLIANCE.md
@@ -311,7 +311,7 @@ MIESC maps findings to 12 international standards, including:
 |----------|----------------|
 | Version Control | Git with signed commits |
 | Code Review | Pull request required |
-| Testing | 9130 tests passed, 1 skipped in the latest full local regression (v6.0.0); 88% line coverage; 75% mutation score on core v6 modules |
+| Testing | 9130 tests passed, 1 skipped in the latest full local regression (v6.0.0); 81% line coverage; 75% mutation score on core v6 modules — figures reconciled with the release-validation record in [POST_RELEASE_VALIDATION_2026-07-13.md](./POST_RELEASE_VALIDATION_2026-07-13.md) |
 | CI/CD | GitHub Actions pipeline |
 | Security Scanning | Bandit, pip-audit, safety (dependencies); Trivy + CodeQL SARIF upload (Docker image) — see `.github/workflows/ci.yml` |
 | Documentation | MkDocs with versioning |

--- a/docs/policies/DPG-COMPLIANCE_ES.md
+++ b/docs/policies/DPG-COMPLIANCE_ES.md
@@ -313,7 +313,7 @@ MIESC mapea hallazgos a 12 estándares internacionales:
 |----------|----------------|
 | Control de Versiones | Git con commits firmados |
 | Revisión de Código | Pull request requerido |
-| Pruebas | 9130 pruebas pasando, 1 omitida en la última regresión local completa (v6.0.0); 88% de cobertura de líneas; 75% de mutation score en módulos core v6 |
+| Pruebas | 9130 pruebas pasando, 1 omitida en la última regresión local completa (v6.0.0); 81% de cobertura de líneas; 75% de mutation score en módulos core v6 — cifras conciliadas con el registro de validación de release en [POST_RELEASE_VALIDATION_2026-07-13.md](./POST_RELEASE_VALIDATION_2026-07-13.md) |
 | CI/CD | Pipeline de GitHub Actions |
 | Escaneo de Seguridad | Bandit, pip-audit, safety (dependencias); Trivy + carga SARIF a CodeQL (imagen Docker) — ver `.github/workflows/ci.yml` |
 | Documentación | MkDocs con versionado |

--- a/docs/policies/DPGA_Application_Responses.csv
+++ b/docs/policies/DPGA_Application_Responses.csv
@@ -9,7 +9,7 @@ General Information,Type of Digital Solution,Software
 2. Open Licensing,License,AGPL-3.0
 2. Open Licensing,Evidence,https://github.com/fboiero/MIESC/blob/main/LICENSE
 3. Clear Ownership,Owner Name,Fernando Boiero
-3. Clear Ownership,Evidence,"https://github.com/fboiero/MIESC, https://github.com/fboiero/MIESC/blob/main/CONTRIBUTORS.md"
+3. Clear Ownership,Evidence,"https://github.com/fboiero/MIESC, https://github.com/fboiero/MIESC/blob/main/docs/CONTRIBUTORS.md"
 3. Clear Ownership,Organization Type,Individual / Academic Researcher
 3. Clear Ownership,Country,Argentina
 3. Clear Ownership,Own all code,Yes
@@ -21,10 +21,10 @@ General Information,Type of Digital Solution,Software
 6. Data Extraction,Formats,"JSON, API, CSV, HTML, Markdown, YAML, PDF"
 6. Data Extraction,Evidence,"REST API with OpenAPI 3.0 spec, SARIF export, CLI with multiple output formats. See: https://github.com/fboiero/MIESC/blob/main/docs/openapi.yaml"
 7. Privacy & Laws,Laws Compliance,"GDPR, CCPA, Ley de Proteccion de Datos Personales N 25.326 (Argentina), LGPD (Brazil)"
-7. Privacy & Laws,Evidence,"https://github.com/fboiero/MIESC/blob/main/PRIVACY.md - All processing is local, no data collection, no telemetry, AI uses local Ollama."
+7. Privacy & Laws,Evidence,"https://github.com/fboiero/MIESC/blob/main/docs/policies/PRIVACY.md - All processing is local, no data collection, no telemetry, AI uses local Ollama."
 8. Standards,Open Standards,"OpenAPI 3.0, SARIF v2.1, JSON Schema, MCP (Model Context Protocol), SWC Registry, CWE, Semantic Versioning 2.0"
 8. Standards,Best Practices,"Principles for Digital Development, OWASP Secure Coding Practices, Defense in Depth (NIST), Contributor Covenant v2.1, Conventional Commits, PEP 8"
-8. Standards,Evidence,"https://github.com/fboiero/MIESC/blob/main/DPG-COMPLIANCE.md, https://github.com/fboiero/MIESC/blob/main/CODE_OF_CONDUCT.md"
+8. Standards,Evidence,"https://github.com/fboiero/MIESC/blob/main/docs/policies/DPG-COMPLIANCE.md, https://github.com/fboiero/MIESC/blob/main/CODE_OF_CONDUCT.md"
 9A. Data Privacy,Collects PII,No
 9B. Content,Collects Content,No
 9C. Harassment,Enables Interactions,Yes
@@ -33,4 +33,4 @@ Scale,Deployed Countries,Argentina
 Scale,Users,"Universidad de la Defensa Nacional (UNDEF), Universidad Tecnologica Nacional - FRVM, open-source community"
 Scale,Multilingual,Yes
 Scale,Languages,"English, Spanish"
-Scale,Highlights,"https://github.com/fboiero/MIESC, PyPI: pip install miesc, Docker: ghcr.io/fboiero/miesc:5.4.1, 9-layer defense architecture, 35 analysis modules, 95.8% recall SmartBugs, 92.5% recall on EVMBench local extraction (contextual, not an official leaderboard result), 2 academic papers, plugin system for community detectors, $0 with local models"
+Scale,Highlights,"https://github.com/fboiero/MIESC, PyPI: pip install miesc, Docker: ghcr.io/fboiero/miesc:6.0.0, 9-layer defense architecture, 35 analysis modules, 95.8% recall SmartBugs, 92.5% recall on EVMBench local extraction (contextual, not an official leaderboard result), 2 academic papers, plugin system for community detectors, $0 with local models"


### PR DESCRIPTION
## Summary
- add a dated DPGA filing readiness checkpoint
- reconcile DPGA evidence links to canonical docs paths
- correct Docker tag and line-coverage claim to release-validated values

## Validation
- test -f docs/CONTRIBUTORS.md docs/policies/PRIVACY.md docs/policies/DPG-COMPLIANCE.md docs/policies/POST_RELEASE_VALIDATION_2026-07-13.md
- python3 CSV parse for docs/policies/DPGA_Application_Responses.csv
- git diff --check