### PR TITLE
fix(adapters): harden LLM output parsing against hostile shapes

### DIFF
--- a/miesc/adapters/frontier_llm_adapter.py
+++ b/miesc/adapters/frontier_llm_adapter.py
@@ -452,14 +452,19 @@ class FrontierLLMAdapter(ToolAdapter):
         # Normalize findings — handle diverse key names from different LLM responses
         normalized = []
         for f in findings:
-            title = (
+            # LLM output is untrusted: a hostile/atypical response may include a
+            # non-dict entry or a non-string ``type``. Guard both so normalization
+            # never raises (a crash here aborts the whole scan).
+            if not isinstance(f, dict):
+                continue
+            title = str(
                 f.get("title")
                 or f.get("vulnerability")
                 or f.get("name")
                 or f.get("type")
                 or "Unknown"
             )
-            ftype = (
+            ftype = str(
                 f.get("type") or f.get("category") or f.get("vulnerability_type") or "logic_error"
             )
             severity = f.get("severity") or "Medium"

--- a/miesc/adapters/gptscan_adapter.py
+++ b/miesc/adapters/gptscan_adapter.py
@@ -489,15 +489,25 @@ Respond ONLY with valid JSON. Report ONLY vulnerabilities you are CONFIDENT abou
             if json_str:
                 parsed = json.loads(repair_common_json_errors(json_str))
 
-                # Extract findings from parsed JSON
-                vulnerabilities = parsed.get("vulnerabilities", [])
+                # Extract findings from parsed JSON. Guard against hostile/atypical
+                # LLM output where ``parsed`` is not a dict or ``vulnerabilities`` is
+                # not a list of dicts — otherwise iteration / .get() / .upper() would
+                # crash into the broad except below and mask the parse failure as a
+                # clean (zero-finding) scan.
+                vulnerabilities = (
+                    parsed.get("vulnerabilities", []) if isinstance(parsed, dict) else []
+                )
+                if not isinstance(vulnerabilities, list):
+                    vulnerabilities = []
 
                 for idx, vuln in enumerate(vulnerabilities):
+                    if not isinstance(vuln, dict):
+                        continue
                     finding = {
                         "id": f"gptscan-{idx+1}",
                         "title": vuln.get("title", "AI-detected vulnerability"),
                         "description": vuln.get("description", ""),
-                        "severity": vuln.get("severity", "MEDIUM").upper(),
+                        "severity": str(vuln.get("severity", "MEDIUM")).upper(),
                         "confidence": vuln.get("confidence", 0.75),
                         "category": vuln.get("type", "ai_detected_pattern"),
                         "location": {

--- a/tests/test_llm_adapter_parse_hardening.py
+++ b/tests/test_llm_adapter_parse_hardening.py
@@ -1,0 +1,82 @@
+"""Regression tests: LLM adapters must not crash (or silently fail clean) on
+hostile/malformed model output.
+
+LLM responses are untrusted — a malicious contract can influence them via prompt
+injection, and local/quantized models emit off-spec shapes. Normalization must
+tolerate non-string field values and non-dict/list containers rather than raising
+(which aborts the scan) or crashing into a broad ``except`` that masks the parse
+failure as a clean, zero-finding result.
+"""
+
+from unittest.mock import patch
+
+from miesc.adapters.frontier_llm_adapter import FrontierLLMAdapter
+from miesc.adapters.gptscan_adapter import GPTScanAdapter
+from miesc.core.tool_protocol import ToolStatus
+
+# --------------------------------------------------------------------------- #
+# FrontierLLM: normalization loop in analyze()
+# --------------------------------------------------------------------------- #
+
+
+def test_frontier_analyze_survives_hostile_finding_shapes(tmp_path):
+    """A non-string ``type`` or a non-dict finding must not crash analyze()."""
+    contract = tmp_path / "c.sol"
+    contract.write_text("contract C {}")
+
+    hostile = [
+        {"type": 123, "title": "numeric type"},  # int type -> old .lower() crash
+        "i am not a dict object",  # non-dict finding -> old .get() crash
+        {"type": ["reentrancy"], "severity": 5},  # list type + non-string severity
+    ]
+
+    with (
+        patch.object(FrontierLLMAdapter, "is_available", return_value=ToolStatus.AVAILABLE),
+        patch.object(FrontierLLMAdapter, "_get_provider", return_value="openai"),
+        patch.object(FrontierLLMAdapter, "_analyze_openai", return_value=hostile),
+    ):
+        result = FrontierLLMAdapter().analyze(str(contract))
+
+    # Contract: returns a dict, does not raise, and did not error out.
+    assert isinstance(result, dict)
+    assert result.get("status") != "error"
+    # The two dict findings normalize; the non-dict entry is skipped.
+    assert isinstance(result.get("findings"), list)
+
+
+# --------------------------------------------------------------------------- #
+# GPTScan: _parse_gptscan_output
+# --------------------------------------------------------------------------- #
+
+
+def test_gptscan_parse_string_vulnerabilities_is_not_a_crash():
+    """``vulnerabilities`` as a string must yield [] (not iterate chars & crash)."""
+    adapter = GPTScanAdapter()
+    out = adapter._parse_gptscan_output('{"vulnerabilities": "none found"}', "c.sol")
+    assert out == []
+
+
+def test_gptscan_parse_non_dict_json_is_not_a_crash():
+    """Top-level JSON that is not an object must yield [] (no .get on a list)."""
+    adapter = GPTScanAdapter()
+    out = adapter._parse_gptscan_output("[1, 2, 3]", "c.sol")
+    assert out == []
+
+
+def test_gptscan_parse_skips_non_dict_entries_keeps_real():
+    """A non-dict entry in the list is skipped; a valid dict is still parsed."""
+    adapter = GPTScanAdapter()
+    payload = '{"vulnerabilities": ["not a dict", {"title": "Real", "severity": "high"}]}'
+    out = adapter._parse_gptscan_output(payload, "c.sol")
+    assert len(out) == 1
+    assert out[0]["title"] == "Real"
+    assert out[0]["severity"] == "HIGH"
+
+
+def test_gptscan_parse_non_string_severity_does_not_crash():
+    """A non-string severity must be coerced, not crash .upper()."""
+    adapter = GPTScanAdapter()
+    payload = '{"vulnerabilities": [{"title": "X", "severity": 5}]}'
+    out = adapter._parse_gptscan_output(payload, "c.sol")
+    assert len(out) == 1
+    assert out[0]["severity"] == "5"


### PR DESCRIPTION
## Context

Found via an adversarial audit of how MIESC's analysis adapters parse **untrusted** external output. LLM responses are attacker-influenceable (prompt injection via contract comments) and off-spec from local/quantized models. Two adapters mishandled atypical output.

## 1. frontier_llm_adapter — crash aborts the scan (MEDIUM)

The per-finding normalization loop assumed string fields:
- a non-string `type` (e.g. `123`, `["x"]`) made `ftype.lower()` raise `AttributeError`;
- `title` falls back to `f.get("type")`, so the **dedup** pass's `title.lower()` raised too (a 2nd crash the regression test surfaced);
- a non-dict finding entry made `f.get(...)` raise.

None are guarded (the loop runs outside the API `try/except`), so any of these aborts the whole scan.

**Fix:** coerce `type`/`title` with `str(...)`, skip non-dict findings with `isinstance`.

## 2. gptscan_adapter — silent fail-open (LOW)

`_parse_gptscan_output` crashed into its broad `except Exception` when `parsed` was not a dict, `vulnerabilities` was not a list, an entry was not a dict, or `severity` was non-string. The except returns zero findings **while `analyze()` still reports `status=success`** — a parse failure masked as a clean scan.

**Fix:** guard each shape (`isinstance` on parsed / vulnerabilities / entry, `str(...)` on severity) so malformed output yields a genuine, non-crashing result.

## Tests

New `tests/test_llm_adapter_parse_hardening.py` — 5 cases (frontier hostile shapes; gptscan string-vulns, non-dict-JSON, mixed entries, non-string severity). All pass; without the fixes the frontier case raises and the gptscan cases crash-to-empty. 29 existing frontier/gptscan tests still green. ruff + black clean.