### PR TITLE
feat(formal): economic invariants → Echidna end-to-end detection (Tier-2 payoff)

### DIFF
--- a/examples/economic-invariants/SafeVault.sol
+++ b/examples/economic-invariants/SafeVault.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+// Fixed ERC-4626-style vault using INTERNAL asset accounting. totalAssets()
+// returns a variable that only changes through deposit/redeem, so a direct
+// token donation cannot inflate the share price. This neutralises the classic
+// first-deposit / donation inflation attack.
+contract SafeVault {
+    IERC20 public asset;
+    uint256 public totalSupply;
+    uint256 private _accountedAssets;
+
+    mapping(address => uint256) public balanceOf;
+
+    constructor(address asset_) {
+        asset = IERC20(asset_);
+    }
+
+    function totalAssets() public view returns (uint256) {
+        return _accountedAssets;
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        return supply == 0 ? assets : (assets * supply) / _accountedAssets;
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        return supply == 0 ? shares : (shares * _accountedAssets) / supply;
+    }
+
+    function deposit(uint256 assets, address receiver) public returns (uint256 shares) {
+        shares = convertToShares(assets);
+        asset.transferFrom(msg.sender, address(this), assets);
+        _accountedAssets += assets;
+        totalSupply += shares;
+        balanceOf[receiver] += shares;
+    }
+
+    function redeem(uint256 shares, address receiver, address owner) public returns (uint256 assets) {
+        assets = convertToAssets(shares);
+        balanceOf[owner] -= shares;
+        totalSupply -= shares;
+        _accountedAssets -= assets;
+        asset.transfer(receiver, assets);
+    }
+}

--- a/examples/economic-invariants/VulnVault.sol
+++ b/examples/economic-invariants/VulnVault.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+// Naive ERC-4626-style vault with the classic first-deposit / donation
+// share-price inflation vulnerability: convertToShares uses the live asset
+// balance, so a direct donation inflates share price and rounds later
+// depositors down to zero shares.
+contract VulnVault {
+    IERC20 public asset;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+
+    constructor(address asset_) {
+        asset = IERC20(asset_);
+    }
+
+    function totalAssets() public view returns (uint256) {
+        return asset.balanceOf(address(this));
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        return supply == 0 ? assets : (assets * supply) / totalAssets();
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        return supply == 0 ? shares : (shares * totalAssets()) / supply;
+    }
+
+    function deposit(uint256 assets, address receiver) public returns (uint256 shares) {
+        shares = convertToShares(assets);
+        asset.transferFrom(msg.sender, address(this), assets);
+        totalSupply += shares;
+        balanceOf[receiver] += shares;
+    }
+
+    function redeem(uint256 shares, address receiver, address owner) public returns (uint256 assets) {
+        assets = convertToAssets(shares);
+        balanceOf[owner] -= shares;
+        totalSupply -= shares;
+        asset.transfer(receiver, assets);
+    }
+}

--- a/miesc/cli/commands/verify.py
+++ b/miesc/cli/commands/verify.py
@@ -114,6 +114,68 @@ def _emit_economic_invariants(
     return {"count": len(invariants), "names": names, "files": files}
 
 
+def _fuzz_economic_invariants(
+    contract_path: str,
+    invariant_names: list[str],
+    test_limit: int,
+    timeout: int,
+    quiet: bool,
+) -> Dict[str, Any]:
+    """Run the selected economic invariants through Echidna end-to-end.
+
+    Generates a runnable harness (mock asset + driver functions + property),
+    runs Echidna, and maps falsified properties to MIESC findings. Gated behind
+    Echidna availability — gracefully skips (never fabricates) when absent.
+    """
+    from miesc.formal.economic_harness import run_economic_fuzz, supported_invariants
+
+    runnable = [n for n in invariant_names if n in supported_invariants()]
+    if not runnable:
+        if not quiet:
+            info(
+                "No fuzzable economic invariants for this contract "
+                f"(supported: {sorted(supported_invariants())})."
+            )
+        return {"status": "skipped", "findings": []}
+
+    if not quiet:
+        info(f"Fuzzing {len(runnable)} economic invariant(s) with Echidna...")
+
+    result = run_economic_fuzz(
+        contract_path,
+        runnable,
+        test_limit=test_limit,
+        timeout=timeout,
+    )
+
+    if not quiet:
+        status = result.get("status")
+        if status == "skipped":
+            warning(result.get("reason", "Economic fuzzing skipped."))
+        elif status == "error":
+            error(f"Economic fuzzing error: {result.get('reason')}")
+        elif status == "clean":
+            success(
+                "Economic invariants held under fuzzing "
+                f"({', '.join(result.get('properties', []))}) — no violations."
+            )
+        elif status == "detected":
+            console.print(
+                f"\n[bold red]Economic bug(s) detected via fuzzing:[/bold red] "
+                f"{len(result['findings'])}"
+            )
+            for f in result["findings"]:
+                console.print(
+                    f"  • [{f['severity']}] {f.get('invariant', f.get('property'))}: "
+                    f"{f.get('description', '')[:100]}"
+                )
+                seq = f.get("call_sequence") or []
+                for call in seq[:6]:
+                    console.print(f"      ↳ {call}")
+
+    return result
+
+
 @click.command()
 @click.argument("contract_path", type=click.Path(exists=True))
 @click.option(
@@ -182,6 +244,19 @@ def _emit_economic_invariants(
     default=None,
     help="With --economic-invariants: directory to write CVL/Echidna/Foundry artifacts.",
 )
+@click.option(
+    "--fuzz",
+    is_flag=True,
+    help="With --economic-invariants: run the generated economic invariants through "
+    "Echidna end-to-end (generate a harness, fuzz, report violations as findings). "
+    "Requires Echidna; gracefully skipped when absent.",
+)
+@click.option(
+    "--fuzz-test-limit",
+    type=int,
+    default=30000,
+    help="With --fuzz: Echidna test limit (default: 30000, ~1-3 min).",
+)
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 def verify(
     contract_path: str,
@@ -195,6 +270,8 @@ def verify(
     poc_check: bool,
     economic_invariants: bool,
     invariants_out: str | None,
+    fuzz: bool,
+    fuzz_test_limit: int,
     quiet: bool,
 ) -> None:
     """Run formal-verification provers against a contract.
@@ -216,12 +293,29 @@ def verify(
 
     # Economic / business-logic invariant synthesis (offline, prover-independent).
     econ_summary: Optional[Dict[str, Any]] = None
+    econ_fuzz: Optional[Dict[str, Any]] = None
     if economic_invariants:
         try:
             econ_summary = _emit_economic_invariants(contract_path, invariants_out, quiet)
         except Exception as e:  # pragma: no cover - defensive
             error(f"Economic invariant synthesis failed: {e}")
             sys.exit(1)
+
+        # End-to-end: run the generated economic invariants through Echidna.
+        if fuzz:
+            try:
+                econ_fuzz = _fuzz_economic_invariants(
+                    contract_path,
+                    econ_summary.get("names", []),
+                    fuzz_test_limit,
+                    timeout,
+                    quiet,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                error(f"Economic fuzzing failed: {e}")
+                sys.exit(1)
+    elif fuzz:
+        warning("--fuzz has no effect without --economic-invariants.")
 
     try:
         from miesc.formal import SpecRunner
@@ -315,10 +409,13 @@ def verify(
             error("kontrol not installed; " "see https://docs.runtimeverification.com/kontrol")
             sys.exit(1)
 
+    # A fuzz-detected economic bug is a real failure.
+    econ_bug = bool(econ_fuzz and econ_fuzz.get("status") == "detected")
+
     if not results:
         if econ_summary is not None:
             # Economic invariant emission already did useful, prover-independent work.
-            sys.exit(0)
+            sys.exit(1 if econ_bug else 0)
         warning("No provers were run (none installed for selected --tool).")
         sys.exit(0)
 
@@ -390,6 +487,6 @@ def verify(
     elif poc_check:
         info("--poc-check has no effect without --poc.")
 
-    # Exit code: 1 if any prover reported failures
+    # Exit code: 1 if any prover reported failures or a fuzzed economic bug hit.
     any_failed = any(r.status == "failed" for r in results.values())
-    sys.exit(1 if any_failed else 0)
+    sys.exit(1 if (any_failed or econ_bug) else 0)

--- a/miesc/formal/__init__.py
+++ b/miesc/formal/__init__.py
@@ -8,6 +8,13 @@ Bridges MIESC findings to formal verification tools:
   - Halmos (symbolic testing)
 """
 
+from miesc.formal.economic_harness import (
+    EconomicHarnessBuilder,
+    HarnessArtifact,
+    RunnableProperty,
+    run_economic_fuzz,
+    supported_invariants,
+)
 from miesc.formal.economic_invariants import (
     ECONOMIC_INVARIANT_TEMPLATES,
     EconomicInvariantTemplate,
@@ -34,8 +41,13 @@ from miesc.formal.unified_report import (
 __all__ = [
     "Counterexample",
     "ECONOMIC_INVARIANT_TEMPLATES",
+    "EconomicHarnessBuilder",
     "EconomicInvariantTemplate",
     "GeneratedSpec",
+    "HarnessArtifact",
+    "RunnableProperty",
+    "run_economic_fuzz",
+    "supported_invariants",
     "ProverVerdict",
     "SpecFormat",
     "SpecGenerator",

--- a/miesc/formal/economic_harness.py
+++ b/miesc/formal/economic_harness.py
@@ -1,0 +1,512 @@
+"""
+Economic-invariant Echidna harness bridge.
+==========================================
+
+`economic_invariants.py` *writes down* economic properties (ERC-4626 share-price
+inflation, solvency, ...). `EchidnaAdapter` *runs* Echidna on a contract that
+already contains `echidna_*` properties. Neither, on its own, closes the loop:
+a generated economic property is written in an *inherited/mixin* context (it
+calls `totalSupply()` / `convertToAssets()` as if it lived inside the vault) and
+assumes an asset token, funding and a driver that exercises the attack.
+
+This module is the missing bridge. Given a target contract and a selected set of
+economic invariants it:
+
+  1. Generates a *runnable* Echidna harness — a self-contained deployer contract
+     that deploys a mock ERC-20 asset + the target vault, funds itself, and
+     exposes driver functions (deposit / donate / redeem) that Echidna fuzzes to
+     drive the economic attack.
+  2. Emits, at harness scope, the economic property functions in *deployer*
+     context (target API calls prefixed with `vault.`), derived from the
+     `economic_invariants.py` template library (single source of truth for
+     severity / natural language / related vulnerabilities).
+  3. Runs Echidna on the harness via `EchidnaAdapter` and maps every *falsified*
+     property back to the originating economic invariant → a MIESC finding.
+
+Honesty / scope
+---------------
+The harness generator is concrete for the **ERC-4626 vault** class (the class
+`economic_invariants.py` flags out-of-scope for static analysis). It assumes the
+target vault constructor takes a single asset-token address, and exposes the
+standard `deposit(assets,receiver)` / `redeem(shares,receiver,owner)` /
+`convertToShares` / `convertToAssets` / `totalAssets` / `totalSupply` API. When
+the target diverges the harness will fail to compile and the runner reports that
+honestly rather than fabricating a result.
+
+Author: Fernando Boiero <fboiero@frvm.utn.edu.ar>
+License: AGPL-3.0
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from miesc.formal.economic_invariants import ECONOMIC_INVARIANT_TEMPLATES
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Runnable property forms (deployer/harness context)
+# ---------------------------------------------------------------------------
+#
+# The raw `echidna_property` bodies in economic_invariants.py are written for an
+# *inherited* context (bare `totalSupply()` etc.) and some declare their own
+# state. Here we author the equivalent *deployer-context* form (calls prefixed
+# with `vault.`, state hoisted to harness scope), keyed by the template name.
+# Severity / natural language / related vulnerabilities are still sourced from
+# the template library so there is a single source of truth for metadata.
+
+
+@dataclass
+class RunnableProperty:
+    """A harness-context Echidna property derived from an economic template."""
+
+    template_name: str
+    function_name: str  # echidna_* function name (as Echidna reports it)
+    body: str  # full Solidity function source, deployer context
+    state_decls: List[str] = field(default_factory=list)  # contract-scope vars
+
+    @property
+    def importance(self) -> str:
+        tmpl = ECONOMIC_INVARIANT_TEMPLATES.get(self.template_name)
+        return tmpl.importance if tmpl else "HIGH"
+
+    @property
+    def natural_language(self) -> str:
+        tmpl = ECONOMIC_INVARIANT_TEMPLATES.get(self.template_name)
+        return tmpl.natural_language if tmpl else ""
+
+    @property
+    def related_vulnerabilities(self) -> List[str]:
+        tmpl = ECONOMIC_INVARIANT_TEMPLATES.get(self.template_name)
+        return list(tmpl.related_vulnerabilities) if tmpl else []
+
+    @property
+    def category(self) -> str:
+        tmpl = ECONOMIC_INVARIANT_TEMPLATES.get(self.template_name)
+        return tmpl.category if tmpl else "economic"
+
+
+# Deployer-context runnable forms for the ERC-4626 vault class.
+_RUNNABLE_ERC4626: Dict[str, RunnableProperty] = {
+    "erc4626_first_deposit_guard": RunnableProperty(
+        template_name="erc4626_first_deposit_guard",
+        function_name="echidna_deposit_mints_nonzero_shares",
+        body=(
+            "    // erc4626_first_deposit_guard (deployer-context form).\n"
+            "    // A positive deposit against a funded vault must mint positive shares;\n"
+            "    // a donation-inflated share price rounds this to zero.\n"
+            "    function echidna_deposit_mints_nonzero_shares() public view returns (bool) {\n"
+            "        if (vault.totalAssets() == 0) return true;\n"
+            "        return vault.convertToShares(1) > 0 || vault.totalSupply() == 0;\n"
+            "    }"
+        ),
+    ),
+    "vault_solvency": RunnableProperty(
+        template_name="vault_solvency",
+        function_name="echidna_vault_solvent",
+        body=(
+            "    // vault_solvency (deployer-context form).\n"
+            "    function echidna_vault_solvent() public view returns (bool) {\n"
+            "        return vault.totalAssets() >= vault.convertToAssets(vault.totalSupply());\n"
+            "    }"
+        ),
+    ),
+    "erc4626_share_price_non_decreasing": RunnableProperty(
+        template_name="erc4626_share_price_non_decreasing",
+        function_name="echidna_share_price_non_decreasing",
+        state_decls=["    uint256 private _lastPricePerShare = type(uint256).max;"],
+        body=(
+            "    // erc4626_share_price_non_decreasing (deployer-context form).\n"
+            "    function echidna_share_price_non_decreasing() public returns (bool) {\n"
+            "        if (vault.totalSupply() == 0) return true;\n"
+            "        uint256 pps = vault.convertToAssets(1e18);\n"
+            "        bool ok = pps >= _lastPricePerShare"
+            " || _lastPricePerShare == type(uint256).max;\n"
+            "        if (pps < _lastPricePerShare) _lastPricePerShare = pps;\n"
+            "        return ok;\n"
+            "    }"
+        ),
+    ),
+}
+
+# Bridge-augmented discriminating property (not a verbatim template): a
+# round-trip no-loss check. It is the most robust discriminator for the
+# inflation class — a realistic depositor who deposits then redeems must recover
+# ~their value. Included when first_deposit_guard is selected.
+_ROUND_TRIP_NO_LOSS = RunnableProperty(
+    template_name="erc4626_first_deposit_guard",
+    function_name="echidna_no_inflation_theft",
+    body=(
+        "    // Bridge-augmented: a realistic (1-token) depositor must not lose value to\n"
+        "    // share-price inflation. Robust round-trip discriminator (>=99% recovered).\n"
+        "    function echidna_no_inflation_theft() public view returns (bool) {\n"
+        "        if (vault.totalSupply() == 0) return true;\n"
+        "        uint256 probe = 1e18;\n"
+        "        uint256 shares = vault.convertToShares(probe);\n"
+        "        uint256 back = vault.convertToAssets(shares);\n"
+        "        return back * 100 >= probe * 99;\n"
+        "    }"
+    ),
+)
+
+
+def supported_invariants() -> set[str]:
+    """Economic invariant names for which a runnable harness form exists."""
+    return set(_RUNNABLE_ERC4626.keys())
+
+
+# ---------------------------------------------------------------------------
+# Harness generation
+# ---------------------------------------------------------------------------
+
+_MOCK_ERC20 = """contract MockERC20 {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (allowance[from][msg.sender] != type(uint256).max) {
+            allowance[from][msg.sender] -= amount;
+        }
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}"""
+
+_DRIVERS = """    // ---- driver functions Echidna fuzzes to drive the attack ----
+    function h_deposit(uint256 assets) public {
+        assets = 1 + (assets % 1e24);
+        vault.deposit(assets, address(this));
+    }
+
+    function h_donate(uint256 amount) public {
+        amount = amount % 1e24;
+        token.transfer(address(vault), amount);
+    }
+
+    function h_redeem(uint256 shares) public {
+        uint256 bal = vault.balanceOf(address(this));
+        if (bal == 0) return;
+        shares = 1 + (shares % bal);
+        vault.redeem(shares, address(this), address(this));
+    }"""
+
+
+@dataclass
+class HarnessArtifact:
+    """A generated, runnable Echidna harness for a target contract."""
+
+    source: str
+    harness_contract_name: str
+    target_name: str
+    properties: List[RunnableProperty]
+    import_path: str
+
+    @property
+    def property_map(self) -> Dict[str, RunnableProperty]:
+        """echidna_* function name -> RunnableProperty (for violation mapping)."""
+        return {p.function_name: p for p in self.properties}
+
+
+def _extract_pragma(source: str) -> str:
+    m = re.search(r"pragma\s+solidity[^;]+;", source)
+    return m.group(0) if m else "pragma solidity ^0.8.0;"
+
+
+class EconomicHarnessBuilder:
+    """Builds runnable Echidna harnesses from economic invariant selections."""
+
+    def build(
+        self,
+        target_source: str,
+        target_name: str,
+        invariant_names: List[str],
+        target_import: str,
+        *,
+        include_round_trip: bool = True,
+    ) -> Optional[HarnessArtifact]:
+        """Generate a harness for `target_name`, or None if nothing is runnable.
+
+        Args:
+            target_source: Solidity source of the target (for pragma extraction).
+            target_name:   Solidity contract name to deploy in the harness.
+            invariant_names: Selected economic invariant names.
+            target_import: Relative import path to the target file (e.g. "./Vault.sol").
+            include_round_trip: Also emit the robust round-trip discriminator when
+                the first-deposit guard is selected.
+        """
+        props: List[RunnableProperty] = []
+        seen: set[str] = set()
+        for name in invariant_names:
+            runnable = _RUNNABLE_ERC4626.get(name)
+            if runnable and runnable.function_name not in seen:
+                props.append(runnable)
+                seen.add(runnable.function_name)
+        if include_round_trip and "erc4626_first_deposit_guard" in invariant_names:
+            if _ROUND_TRIP_NO_LOSS.function_name not in seen:
+                props.append(_ROUND_TRIP_NO_LOSS)
+                seen.add(_ROUND_TRIP_NO_LOSS.function_name)
+
+        if not props:
+            return None
+
+        pragma = _extract_pragma(target_source)
+        harness_name = "MIESCEconomicHarness"
+
+        state_decls: List[str] = []
+        for p in props:
+            state_decls.extend(p.state_decls)
+
+        parts: List[str] = [
+            "// SPDX-License-Identifier: AGPL-3.0",
+            "// Auto-generated by MIESC EconomicHarnessBuilder — do not edit by hand.",
+            pragma,
+            "",
+            f'import "{target_import}";',
+            "",
+            _MOCK_ERC20,
+            "",
+            f"contract {harness_name} {{",
+            "    MockERC20 public token;",
+            f"    {target_name} public vault;",
+        ]
+        if state_decls:
+            parts.extend(state_decls)
+        parts += [
+            "",
+            "    constructor() {",
+            "        token = new MockERC20();",
+            f"        vault = new {target_name}(address(token));",
+            "        token.mint(address(this), 1e30);",
+            "        token.approve(address(vault), type(uint256).max);",
+            "    }",
+            "",
+            _DRIVERS,
+            "",
+        ]
+        for p in props:
+            parts.append(p.body)
+            parts.append("")
+        parts.append("}")
+
+        return HarnessArtifact(
+            source="\n".join(parts) + "\n",
+            harness_contract_name=harness_name,
+            target_name=target_name,
+            properties=props,
+            import_path=target_import,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner: generate harness -> run Echidna -> map violations to MIESC findings
+# ---------------------------------------------------------------------------
+
+_IMPORTANCE_TO_SEVERITY = {
+    "CRITICAL": "critical",
+    "HIGH": "high",
+    "MEDIUM": "medium",
+    "LOW": "low",
+}
+
+
+def _detect_target_contract_name(source: str) -> Optional[str]:
+    """Best-effort: last top-level `contract X` that looks like the vault.
+
+    Prefers a contract whose body mentions ERC-4626-ish API; falls back to the
+    last declared contract.
+    """
+    names: List[str] = re.findall(r"\bcontract\s+([A-Za-z_]\w*)", source)
+    if not names:
+        return None
+    # Prefer a vault-looking contract if several are declared.
+    for name in names:
+        block_match = re.search(rf"contract\s+{re.escape(name)}\b(.*?)$", source, re.DOTALL)
+        block = block_match.group(1) if block_match else ""
+        low = block.lower()
+        if "converttoshares" in low or "converttoassets" in low or "totalassets" in low:
+            return str(name)
+    return str(names[-1])
+
+
+def run_economic_fuzz(
+    target_path: str,
+    invariant_names: List[str],
+    *,
+    target_name: Optional[str] = None,
+    test_limit: int = 30000,
+    timeout: int = 300,
+    adapter: Any = None,
+    keep_harness: bool = False,
+) -> Dict[str, Any]:
+    """Generate a harness for the target, run Echidna, map violations to findings.
+
+    Returns a dict:
+      status: "detected" | "clean" | "skipped" | "error"
+      reason: present when skipped/error
+      harness_path: path to the generated harness (when written)
+      properties: list of echidna_* property names run
+      findings: MIESC findings (one per falsified economic property)
+      echidna: raw adapter result (for auditing)
+
+    Echidna availability is checked up-front; when absent the run is *skipped*
+    gracefully (never fabricated).
+    """
+    from miesc.adapters.echidna_adapter import EchidnaAdapter
+    from miesc.core.tool_protocol import ToolStatus
+
+    if adapter is None:
+        adapter = EchidnaAdapter(config={"test_limit": test_limit, "timeout": timeout})
+
+    if adapter.is_available() != ToolStatus.AVAILABLE:
+        return {
+            "status": "skipped",
+            "reason": "Echidna not installed (brew install echidna). "
+            "Economic invariants were generated but not fuzzed.",
+            "properties": [],
+            "findings": [],
+        }
+
+    src = Path(target_path).read_text(encoding="utf-8")
+    resolved_name = target_name or _detect_target_contract_name(src)
+    if not resolved_name:
+        return {
+            "status": "error",
+            "reason": f"Could not detect a target contract name in {target_path}.",
+            "properties": [],
+            "findings": [],
+        }
+
+    builder = EconomicHarnessBuilder()
+    artifact = builder.build(
+        target_source=src,
+        target_name=resolved_name,
+        invariant_names=invariant_names,
+        target_import=f"./{Path(target_path).name}",
+    )
+    if artifact is None:
+        return {
+            "status": "skipped",
+            "reason": "No runnable economic harness form for the selected invariants "
+            f"(supported: {sorted(supported_invariants())}).",
+            "properties": [],
+            "findings": [],
+        }
+
+    # Write the harness next to the target so the relative import resolves.
+    target_dir = Path(target_path).resolve().parent
+    fd, harness_path = tempfile.mkstemp(
+        prefix="miesc_econ_harness_", suffix=".sol", dir=str(target_dir)
+    )
+    os.close(fd)
+    Path(harness_path).write_text(artifact.source, encoding="utf-8")
+
+    try:
+        result = adapter.analyze(
+            harness_path,
+            contract_name=artifact.harness_contract_name,
+            test_mode="property",
+        )
+    finally:
+        if not keep_harness:
+            try:
+                os.unlink(harness_path)
+            except OSError:
+                pass
+
+    if result.get("status") != "success":
+        return {
+            "status": "error",
+            "reason": result.get("error", "Echidna run failed"),
+            "harness_path": harness_path if keep_harness else None,
+            "properties": [p.function_name for p in artifact.properties],
+            "findings": [],
+            "echidna": result,
+        }
+
+    prop_map = artifact.property_map
+    findings: List[Dict[str, Any]] = []
+    for raw in result.get("findings", []):
+        prop_name = raw.get("property", "")
+        runnable = prop_map.get(prop_name)
+        if runnable is None:
+            # A violated property we did not author (defensive) — surface as-is.
+            findings.append(
+                {
+                    "tool": "echidna-economic",
+                    "type": "economic_invariant_violation",
+                    "severity": "high",
+                    "title": f"Economic property {prop_name} falsified",
+                    "property": prop_name,
+                    "description": raw.get("description", ""),
+                    "call_sequence": raw.get("call_sequence", []),
+                }
+            )
+            continue
+        findings.append(
+            {
+                "tool": "echidna-economic",
+                "type": "economic_invariant_violation",
+                "severity": _IMPORTANCE_TO_SEVERITY.get(runnable.importance, "high"),
+                "title": f"Economic invariant violated: {runnable.template_name}",
+                "invariant": runnable.template_name,
+                "property": prop_name,
+                "category": runnable.category,
+                "description": runnable.natural_language
+                or f"Echidna falsified {prop_name} during fuzzing.",
+                "related_vulnerabilities": runnable.related_vulnerabilities,
+                "recommendation": (
+                    "Echidna found a call sequence that violates this economic "
+                    "invariant. Review the counterexample and harden the contract "
+                    "(e.g. internal asset accounting or a first-deposit guard)."
+                ),
+                "call_sequence": raw.get("call_sequence", []),
+                "contract": target_path,
+            }
+        )
+
+    return {
+        "status": "detected" if findings else "clean",
+        "target": target_path,
+        "target_contract": resolved_name,
+        "harness_path": harness_path if keep_harness else None,
+        "properties": [p.function_name for p in artifact.properties],
+        "findings": findings,
+        "echidna": {
+            "tests_run": result.get("tests_run"),
+            "execution_time": result.get("execution_time"),
+            "test_limit": result.get("test_limit"),
+        },
+    }
+
+
+__all__ = [
+    "EconomicHarnessBuilder",
+    "HarnessArtifact",
+    "RunnableProperty",
+    "run_economic_fuzz",
+    "supported_invariants",
+]

--- a/tests/test_economic_harness.py
+++ b/tests/test_economic_harness.py
@@ -1,0 +1,224 @@
+"""
+Tests for the economic-invariant Echidna harness bridge.
+
+Covers, WITHOUT requiring Echidna to be installed:
+  - Harness generation (structure, imported target, driver functions, property
+    functions, hoisted state declarations, round-trip augmentation).
+  - Violation parsing / finding mapping via a MOCKED adapter.
+  - Graceful no-op when Echidna is absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from miesc.core.tool_protocol import ToolStatus
+from miesc.formal.economic_harness import (
+    EconomicHarnessBuilder,
+    _detect_target_contract_name,
+    run_economic_fuzz,
+    supported_invariants,
+)
+
+VAULT_SRC = """// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IERC20 { function balanceOf(address) external view returns (uint256); }
+
+contract MyVault {
+    uint256 public totalSupply;
+    function totalAssets() public view returns (uint256) {}
+    function convertToShares(uint256 a) public view returns (uint256) {}
+    function convertToAssets(uint256 s) public view returns (uint256) {}
+    function deposit(uint256 a, address r) public returns (uint256) {}
+    function redeem(uint256 s, address r, address o) public returns (uint256) {}
+    function balanceOf(address) public view returns (uint256) {}
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# supported_invariants
+# ---------------------------------------------------------------------------
+
+
+def test_supported_invariants_is_erc4626_set():
+    supported = supported_invariants()
+    assert "erc4626_first_deposit_guard" in supported
+    assert "vault_solvency" in supported
+    assert "erc4626_share_price_non_decreasing" in supported
+
+
+# ---------------------------------------------------------------------------
+# target contract detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_contract_prefers_vault():
+    assert _detect_target_contract_name(VAULT_SRC) == "MyVault"
+
+
+def test_detect_target_contract_none_when_no_contract():
+    assert _detect_target_contract_name("pragma solidity ^0.8.0;") is None
+
+
+# ---------------------------------------------------------------------------
+# harness generation
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessBuilder:
+    def test_build_none_when_no_supported_invariants(self):
+        art = EconomicHarnessBuilder().build(
+            VAULT_SRC, "MyVault", ["total_supply_equals_sum_balances"], "./V.sol"
+        )
+        assert art is None
+
+    def test_build_generates_runnable_harness(self):
+        art = EconomicHarnessBuilder().build(
+            VAULT_SRC,
+            "MyVault",
+            ["erc4626_first_deposit_guard", "vault_solvency"],
+            "./MyVault.sol",
+        )
+        assert art is not None
+        src = art.source
+        # Pragma inherited from target
+        assert "pragma solidity ^0.8.19;" in src
+        # Imports the target, deploys mock + vault
+        assert 'import "./MyVault.sol";' in src
+        assert "contract MockERC20" in src
+        assert "vault = new MyVault(address(token));" in src
+        # Driver functions Echidna will fuzz
+        assert "function h_deposit(" in src
+        assert "function h_donate(" in src
+        assert "function h_redeem(" in src
+        # Property functions (deployer context — prefixed with vault.)
+        assert "function echidna_deposit_mints_nonzero_shares()" in src
+        assert "function echidna_vault_solvent()" in src
+        assert "vault.convertToShares(1)" in src
+        # Round-trip discriminator auto-added with first_deposit_guard
+        assert "function echidna_no_inflation_theft()" in src
+
+    def test_state_decls_hoisted_for_share_price(self):
+        art = EconomicHarnessBuilder().build(
+            VAULT_SRC,
+            "MyVault",
+            ["erc4626_share_price_non_decreasing"],
+            "./MyVault.sol",
+        )
+        assert art is not None
+        # The stateful property's variable is hoisted to contract scope.
+        assert "_lastPricePerShare" in art.source
+        assert "function echidna_share_price_non_decreasing()" in art.source
+
+    def test_no_round_trip_when_disabled(self):
+        art = EconomicHarnessBuilder().build(
+            VAULT_SRC,
+            "MyVault",
+            ["erc4626_first_deposit_guard"],
+            "./MyVault.sol",
+            include_round_trip=False,
+        )
+        assert art is not None
+        assert "echidna_no_inflation_theft" not in art.source
+
+    def test_property_map_keys_are_function_names(self):
+        art = EconomicHarnessBuilder().build(
+            VAULT_SRC, "MyVault", ["vault_solvency"], "./MyVault.sol"
+        )
+        assert art is not None
+        assert "echidna_vault_solvent" in art.property_map
+
+
+# ---------------------------------------------------------------------------
+# run_economic_fuzz with a MOCKED adapter (no Echidna required)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    def __init__(self, available: bool, result: Dict[str, Any]):
+        self._available = available
+        self._result = result
+        self.analyzed_path: str | None = None
+
+    def is_available(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._available else ToolStatus.NOT_INSTALLED
+
+    def analyze(self, contract_path: str, **kwargs: Any) -> Dict[str, Any]:
+        self.analyzed_path = contract_path
+        return self._result
+
+
+@pytest.fixture
+def vault_file(tmp_path):
+    p = tmp_path / "MyVault.sol"
+    p.write_text(VAULT_SRC)
+    return str(p)
+
+
+def test_run_skips_gracefully_when_echidna_absent(vault_file):
+    fake = _FakeAdapter(available=False, result={})
+    out = run_economic_fuzz(vault_file, ["erc4626_first_deposit_guard"], adapter=fake)
+    assert out["status"] == "skipped"
+    assert "not installed" in out["reason"].lower()
+    assert out["findings"] == []
+
+
+def test_run_maps_falsified_property_to_finding(vault_file):
+    echidna_result = {
+        "status": "success",
+        "findings": [
+            {
+                "type": "property_violation",
+                "property": "echidna_deposit_mints_nonzero_shares",
+                "description": "Property violated",
+                "call_sequence": ["h_donate(1000)", "h_deposit(0)"],
+            }
+        ],
+        "tests_run": 100,
+        "execution_time": 1.0,
+        "test_limit": 30000,
+    }
+    fake = _FakeAdapter(available=True, result=echidna_result)
+    out = run_economic_fuzz(vault_file, ["erc4626_first_deposit_guard"], adapter=fake)
+    assert out["status"] == "detected"
+    assert len(out["findings"]) == 1
+    f = out["findings"][0]
+    assert f["invariant"] == "erc4626_first_deposit_guard"
+    assert f["severity"] == "critical"  # importance CRITICAL -> critical
+    assert f["tool"] == "echidna-economic"
+    assert "erc4626-inflation" in f["related_vulnerabilities"]
+    assert f["call_sequence"] == ["h_donate(1000)", "h_deposit(0)"]
+
+
+def test_run_clean_when_no_violations(vault_file):
+    echidna_result = {
+        "status": "success",
+        "findings": [],
+        "tests_run": 30000,
+        "execution_time": 5.0,
+        "test_limit": 30000,
+    }
+    fake = _FakeAdapter(available=True, result=echidna_result)
+    out = run_economic_fuzz(vault_file, ["vault_solvency"], adapter=fake)
+    assert out["status"] == "clean"
+    assert out["findings"] == []
+    # Harness was actually generated and handed to the adapter.
+    assert fake.analyzed_path is not None
+    assert fake.analyzed_path.endswith(".sol")
+
+
+def test_run_error_when_echidna_fails(vault_file):
+    fake = _FakeAdapter(available=True, result={"status": "error", "error": "boom"})
+    out = run_economic_fuzz(vault_file, ["vault_solvency"], adapter=fake)
+    assert out["status"] == "error"
+    assert "boom" in out["reason"]
+
+
+def test_run_skips_when_no_runnable_invariant(vault_file):
+    fake = _FakeAdapter(available=True, result={"status": "success", "findings": []})
+    out = run_economic_fuzz(vault_file, ["total_supply_equals_sum_balances"], adapter=fake)
+    assert out["status"] == "skipped"

--- a/tests/test_verify_command.py
+++ b/tests/test_verify_command.py
@@ -378,3 +378,96 @@ class TestEconomicInvariantsFlag:
             ):
                 result = runner.invoke(verify, [vault_contract, "--economic-invariants", "--quiet"])
         assert result.exit_code == 0
+
+
+class TestEconomicFuzzFlag:
+    def test_help_lists_fuzz_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(verify, ["--help"])
+        assert result.exit_code == 0
+        assert "--fuzz" in result.output
+        assert "--fuzz-test-limit" in result.output
+
+    def test_fuzz_without_economic_invariants_warns(self, contract):
+        runner = CliRunner()
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            result = runner.invoke(verify, [contract, "--fuzz", "--quiet"])
+        assert "no effect" in result.output.lower()
+
+    def test_fuzz_detected_bug_sets_exit_one(self, vault_contract):
+        """A fuzz-detected economic bug must drive exit code 1 (real failure)."""
+        runner = CliRunner()
+        detected = {
+            "status": "detected",
+            "properties": ["echidna_deposit_mints_nonzero_shares"],
+            "findings": [
+                {
+                    "severity": "critical",
+                    "invariant": "erc4626_first_deposit_guard",
+                    "property": "echidna_deposit_mints_nonzero_shares",
+                    "description": "share price inflated",
+                    "call_sequence": ["h_donate(1000)", "h_deposit(0)"],
+                }
+            ],
+        }
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            with patch(
+                "miesc.formal.economic_harness.run_economic_fuzz", return_value=detected
+            ) as rf:
+                result = runner.invoke(
+                    verify, [vault_contract, "--economic-invariants", "--fuzz", "--quiet"]
+                )
+                assert rf.called
+        assert result.exit_code == 1
+
+    def test_fuzz_clean_keeps_exit_zero(self, vault_contract):
+        runner = CliRunner()
+        clean = {
+            "status": "clean",
+            "properties": ["echidna_vault_solvent"],
+            "findings": [],
+        }
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            with patch("miesc.formal.economic_harness.run_economic_fuzz", return_value=clean):
+                result = runner.invoke(
+                    verify, [vault_contract, "--economic-invariants", "--fuzz", "--quiet"]
+                )
+        assert result.exit_code == 0
+
+    def test_fuzz_skipped_when_echidna_absent(self, vault_contract):
+        runner = CliRunner()
+        skipped = {"status": "skipped", "reason": "Echidna not installed", "findings": []}
+        with patch("miesc.formal.SpecRunner") as SR:
+            SR.return_value.availability_report.return_value = {
+                "certora": False,
+                "halmos": False,
+                "smtchecker": False,
+                "scribble": False,
+                "kontrol": False,
+            }
+            with patch("miesc.formal.economic_harness.run_economic_fuzz", return_value=skipped):
+                result = runner.invoke(
+                    verify, [vault_contract, "--economic-invariants", "--fuzz", "--quiet"]
+                )
+        assert result.exit_code == 0


### PR DESCRIPTION
Completes Tier-2: MIESC now **detects an economic bug end-to-end via Echidna** — the class the static layer cannot reach. #118 only GENERATED invariant artifacts; this RUNS them and produces findings.

## The bridge — miesc/formal/economic_harness.py (new)
- `EconomicHarnessBuilder.build()` auto-generates a runnable deployer-context harness: deploys inline MockERC20 + target vault, funds itself, exposes h_deposit/h_donate/h_redeem drivers Echidna fuzzes, emits the economic property fns (target calls prefixed `vault.`). Metadata from the economic_invariants.py template lib.
- `run_economic_fuzz()`: Echidna-availability-gated, runs via the existing EchidnaAdapter, maps each falsified property to a MIESC finding.
- Opt-in: `miesc verify --economic-invariants --fuzz`.

## End-to-end (REAL Echidna 2.2.7 / solc 0.8.33)
| Property | VulnVault | SafeVault |
|---|---|---|
| deposit_mints_nonzero_shares | FALSIFIED | passing |
| no_inflation_theft | FALSIFIED | passing |
| vault_solvent | passing | passing |

Vulnerable: counterexample `h_donate(large)`+`h_deposit(small)` → 2 CRITICAL, exit 1 — first end-to-end detection of the ERC-4626 inflation bug. Fixed (internal accounting): held → no findings.

## Honest scope
Harness auto-generated (no per-vault hand-tuning); on API divergence it won't compile and the runner reports it. vault_solvent honestly does NOT catch inflation. 1-wei probe dust-fragile (documented; fixed example uses internal accounting + round-trip discriminator). CI mocks Echidna; e2e is manual.

Full suite 9523/0, ruff+black clean, no frozen touched.