### PR TITLE
fix(ci): make self-scan workflow robust to missing contracts/ dir

### DIFF
--- a/.github/workflows/miesc-security.yml
+++ b/.github/workflows/miesc-security.yml
@@ -62,12 +62,24 @@ jobs:
           SCAN_TYPE="${{ github.event.inputs.scan_type || 'quick' }}"
           echo "Running MIESC $SCAN_TYPE scan..."
 
-          if [ "$SCAN_TYPE" = "full" ]; then
-            miesc audit full contracts/ --output miesc-results.json --format json || true
-          elif [ "$SCAN_TYPE" = "layer1" ]; then
-            miesc audit layer 1 contracts/ --output miesc-results.json || true
+          # The self-scan targets a contracts/ directory. This repo ships no
+          # such directory (it is a placeholder for downstream consumers), so
+          # scan it only when present and always leave a valid results file so
+          # the SARIF/report steps have something well-formed to consume.
+          if [ -d contracts ]; then
+            if [ "$SCAN_TYPE" = "full" ]; then
+              miesc audit full contracts/ --output miesc-results.json --format json || true
+            elif [ "$SCAN_TYPE" = "layer1" ]; then
+              miesc audit layer 1 contracts/ --output miesc-results.json || true
+            else
+              miesc audit quick contracts/ --output miesc-results.json --format json || true
+            fi
           else
-            miesc audit quick contracts/ --output miesc-results.json --format json || true
+            echo "No contracts/ directory present — nothing to scan; writing empty results."
+          fi
+
+          if [ ! -f miesc-results.json ]; then
+            echo '{"findings": [], "summary": {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}}' > miesc-results.json
           fi
 
       - name: Generate SARIF report


### PR DESCRIPTION
`miesc-security.yml` runs `miesc audit ... contracts/` but this repo ships no `contracts/` directory, so the audit errors ('Path contracts/ does not exist'), `miesc-results.json` is never written, and the downstream SARIF + Combined-Report steps FAIL. The path trigger is `**.sol`, so **any PR adding/changing a .sol file hits this** (e.g. PR #129 which adds example vaults).

Fix: guard the scan on `contracts/` existing, and always leave a valid empty results file so downstream steps succeed. Self-scan still runs normally when a `contracts/` dir is present. No frozen touched.