### PR TITLE
fix(security): stop hallucination detector crashing on textual confidence

### DIFF
--- a/miesc/security/hallucination_detector.py
+++ b/miesc/security/hallucination_detector.py
@@ -35,6 +35,42 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 logger = logging.getLogger(__name__)
 
 
+# Textual confidence labels LLMs commonly emit instead of a number.
+_CONFIDENCE_LABELS = {
+    "critical": 0.95,
+    "very_high": 0.9,
+    "high": 0.85,
+    "medium": 0.6,
+    "moderate": 0.6,
+    "low": 0.35,
+    "very_low": 0.2,
+    "info": 0.2,
+    "informational": 0.2,
+}
+
+
+def _coerce_confidence(value: Any, default: float) -> float:
+    """Best-effort coercion of an untrusted ``confidence`` field to a float.
+
+    LLM findings routinely carry a textual confidence ("high") or a numeric
+    string ("0.8"); a bare ``float(value)`` raises ``ValueError`` on the former
+    and crashes the whole validation run. Numbers pass through (clamped to
+    [0, 1]); numeric strings parse; known labels map to a representative value;
+    anything unrecognized falls back to ``default``.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — treat as default
+        return default
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+    if isinstance(value, str):
+        text = value.strip()
+        try:
+            return max(0.0, min(1.0, float(text)))
+        except ValueError:
+            return _CONFIDENCE_LABELS.get(text.lower().replace(" ", "_"), default)
+    return default
+
+
 class ValidationStatus(Enum):
     """Status of hallucination validation."""
 
@@ -227,7 +263,7 @@ class HallucinationDetector:
     ) -> ValidationResult:
         """Validate a single finding."""
         vuln_type = self._normalize_type(finding.get("type", "") or finding.get("category", ""))
-        original_confidence = float(finding.get("confidence", 0.75))
+        original_confidence = _coerce_confidence(finding.get("confidence", 0.75), 0.75)
         reasons = []
         sources = []
 
@@ -377,7 +413,7 @@ class HallucinationDetector:
         anomalies = []
 
         # Check for suspiciously high confidence with vague description
-        confidence = float(finding.get("confidence", 0.75))
+        confidence = _coerce_confidence(finding.get("confidence", 0.75), 0.75)
         description = str(finding.get("description", ""))
 
         if confidence > 0.9 and len(description) < 50:
@@ -506,7 +542,7 @@ def cross_validate_finding(
         if results
         else ValidationResult(
             status=ValidationStatus.UNVALIDATED,
-            original_confidence=float(finding.get("confidence", 0.5)),
+            original_confidence=_coerce_confidence(finding.get("confidence", 0.5), 0.5),
             adjusted_confidence=0.3,
             reasons=["Validation failed"],
         )

--- a/tests/test_hallucination_confidence_coerce.py
+++ b/tests/test_hallucination_confidence_coerce.py
@@ -1,0 +1,56 @@
+"""Regression tests: hallucination detector must tolerate non-numeric confidence.
+
+LLM findings routinely carry a textual confidence ("high") or a numeric string
+("0.8") rather than a float. A bare ``float("high")`` raises ``ValueError`` and
+crashes the whole validation run — a fail-hard on ordinary model output.
+"""
+
+import pytest
+
+from miesc.security.hallucination_detector import (
+    HallucinationDetector,
+    _coerce_confidence,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0.8, 0.8),
+        (1, 1.0),
+        (5, 1.0),  # clamped to [0, 1]
+        (-2, 0.0),  # clamped
+        ("0.8", 0.8),
+        ("high", 0.85),
+        ("HIGH", 0.85),
+        ("Medium", 0.6),
+        ("low", 0.35),
+        ("informational", 0.2),
+        (True, 0.75),  # bool is not a real confidence -> default
+        (None, 0.75),  # missing/None -> default
+        ("nonsense", 0.75),  # unknown label -> default
+        ([0.9], 0.75),  # wrong type -> default
+    ],
+)
+def test_coerce_confidence(value, expected):
+    assert _coerce_confidence(value, 0.75) == expected
+
+
+def test_validate_findings_survives_textual_confidence():
+    """A finding with confidence='high' must not crash validate_findings."""
+    detector = HallucinationDetector()
+    findings = [
+        {"type": "reentrancy", "confidence": "high", "description": "x"},
+        {"type": "overflow", "confidence": "0.9", "description": "y"},
+        {"type": "access_control", "confidence": "bogus", "description": "z"},
+    ]
+
+    # Must return a validated finding per input, never raise ValueError.
+    results = detector.validate_findings(
+        findings, static_findings=[], contract_code="contract C {}"
+    )
+    assert len(results) == 3
+    for r in results:
+        # original_confidence must have been coerced to a real float in [0, 1].
+        assert isinstance(r.validation.original_confidence, float)
+        assert 0.0 <= r.validation.original_confidence <= 1.0


### PR DESCRIPTION
## Problem

LLM findings routinely report `confidence` as a **label** (`"high"`) or a **numeric string** (`"0.8"`), not a float. Three call sites did:

```python
float(finding.get("confidence", 0.75))
```

The default only applies when the key is **absent** — a present-but-textual value (`"high"`) makes `float(...)` raise `ValueError`, which aborts the entire `validate_findings` run. A fail-hard on ordinary model output (found via an audit of the defensive-security modules).

Call sites: `_validate_single_finding` (single-finding path), the confidence-recompute path, and the validation-failure fallback.

## Fix

New `_coerce_confidence(value, default)`:
- numbers → clamped to `[0, 1]`
- numeric strings (`"0.8"`) → parsed
- known labels (`high/medium/low/critical/info/...`) → representative value
- `bool` / unknown / wrong-type → `default`

All three sites route through it.

## Tests

New `tests/test_hallucination_confidence_coerce.py`: 14 parametrized helper cases + an integration test that `validate_findings` survives `confidence="high"`/`"0.9"`/`"bogus"` and yields floats in `[0,1]`. 62 existing hallucination-detector tests still green. ruff + black clean.