### PR TITLE
fix(agents): bound grep_repo regex to stop injection-driven ReDoS

### DIFF
--- a/miesc/agents/repo_call_graph.py
+++ b/miesc/agents/repo_call_graph.py
@@ -28,7 +28,23 @@ from typing import Dict, List, Optional
 
 from miesc.ml.call_graph import CallEdge, CallGraph, CallGraphBuilder
 
+# Optional: the third-party ``regex`` module supports a per-search ``timeout``
+# that bounds catastrophic backtracking. It is used opportunistically so an
+# injection-steered LLM cannot hang the audit worker with a ReDoS pattern (see
+# ``grep_repo``). When it is not installed, LLM-supplied regexes are never run
+# through the stdlib ``re`` engine (which cannot be interrupted mid-match) — we
+# fall back to a plain substring search, which cannot exhibit ReDoS.
+try:  # pragma: no cover - exercised via presence/absence in the environment
+    import regex as _timeout_regex
+except ImportError:  # pragma: no cover
+    _timeout_regex = None
+
 logger = logging.getLogger(__name__)
+
+# grep_repo hardening: a real grep pattern is short; an over-long one is either a
+# mistake or a ReDoS attempt. The per-search timeout caps pathological patterns.
+_MAX_GREP_PATTERN_CHARS = 200
+_GREP_REGEX_TIMEOUT_S = 0.5
 
 # Same skip rules the benchmark harness uses (evmbench_official_detect.py:34) so
 # we audit implementation code, not tests/libs/mocks/vendored deps.
@@ -228,14 +244,22 @@ class RepoCallGraph:
             needle = (pattern or "").strip()
             if not needle:
                 return "no matches: empty pattern"
+            # Cap pattern length — a real grep pattern is short; an over-long one
+            # is a mistake or a ReDoS attempt.
+            needle = needle[:_MAX_GREP_PATTERN_CHARS]
 
             matcher = None
             # Only bother with regex if it carries regex metacharacters — a plain
-            # identifier is cheaper and safer as a substring search.
-            if any(ch in needle for ch in r".^$*+?()[]{}|\\"):
+            # identifier is cheaper and safer as a substring search. Compile the
+            # (LLM/injection-supplied) pattern ONLY with the ``regex`` module,
+            # whose per-search ``timeout`` bounds catastrophic backtracking; the
+            # stdlib ``re`` engine cannot be interrupted mid-match, so an untrusted
+            # pattern is never handed to it. Without ``regex`` installed we skip
+            # regex entirely and substring-search instead (ReDoS-free).
+            if _timeout_regex is not None and any(ch in needle for ch in r".^$*+?()[]{}|\\"):
                 try:
-                    matcher = re.compile(needle, re.IGNORECASE)
-                except re.error:
+                    matcher = _timeout_regex.compile(needle, _timeout_regex.IGNORECASE)
+                except _timeout_regex.error:
                     matcher = None
             needle_lower = needle.lower()
 
@@ -246,11 +270,16 @@ class RepoCallGraph:
                     break
                 source = self._contracts[name].source
                 for lineno, text in enumerate(source.splitlines(), start=1):
-                    hit = (
-                        matcher.search(text)
-                        if matcher is not None
-                        else needle_lower in text.lower()
-                    )
+                    if matcher is not None:
+                        try:
+                            hit = matcher.search(text, timeout=_GREP_REGEX_TIMEOUT_S) is not None
+                        except TimeoutError:
+                            # Pathological pattern/line tripped the ReDoS guard:
+                            # drop the regex and substring-search the remainder.
+                            matcher = None
+                            hit = needle_lower in text.lower()
+                    else:
+                        hit = needle_lower in text.lower()
                     if not hit:
                         continue
                     out.append(f"{name}:{lineno}: {text.strip()}")

--- a/tests/test_grep_repo_redos.py
+++ b/tests/test_grep_repo_redos.py
@@ -1,0 +1,73 @@
+"""Regression tests: grep_repo must not hang on a ReDoS pattern.
+
+The agentic auditor exposes grep_repo to the LLM, whose pattern argument is
+attacker-influenceable via prompt injection. The old code compiled that pattern
+with the stdlib ``re`` engine (which cannot be interrupted mid-match) and ran it
+against attacker-controlled contract source — a classic catastrophic-backtracking
+denial of service. The fix routes untrusted regexes through the ``regex`` module's
+per-search ``timeout`` (or falls back to substring search), so a pathological
+pattern can never hang the single-threaded audit worker.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+from miesc.agents.repo_call_graph import (
+    RepoCallGraph,
+    _ContractInfo,
+    _timeout_regex,
+)
+from miesc.ml.call_graph import CallGraph
+
+
+def _repo_with_evil_line():
+    """A contract whose body carries a long repetitive line = ReDoS haystack.
+
+    Built directly (not via ``RepoCallGraph.build`` on a temp dir) because the
+    pytest ``tmp_path`` fixture's directory name contains "test", which the
+    build-time ``_SKIP_PATH`` filter would (correctly) skip.
+    """
+    evil = "a" * 5000 + "!"  # long run of 'a' ending in a non-matching char
+    source = "contract Evil {\n" f"    // {evil}\n" "    function withdraw() public {}\n" "}"
+    info = _ContractInfo(name="Evil", source=source, file=Path("Evil.sol"), graph=CallGraph())
+    return RepoCallGraph(contracts={"Evil": info})
+
+
+@pytest.mark.timeout(10)
+def test_grep_repo_redos_pattern_returns_promptly():
+    """A catastrophic-backtracking pattern must return fast, not hang.
+
+    Under the old stdlib-``re`` code this call never returns and pytest-timeout
+    kills the test; under the fix it returns in well under a second.
+    """
+    graph = _repo_with_evil_line()
+    start = time.time()
+    result = graph.grep_repo(r"(a+)+$")
+    elapsed = time.time() - start
+    assert elapsed < 3.0, f"grep_repo took {elapsed:.1f}s — ReDoS not mitigated"
+    assert isinstance(result, str)
+
+
+def test_grep_repo_substring_still_works():
+    """A plain substring pattern must still locate code (no regression)."""
+    graph = _repo_with_evil_line()
+    result = graph.grep_repo("withdraw")
+    assert "withdraw" in result
+    assert "Evil:" in result
+
+
+@pytest.mark.skipif(_timeout_regex is None, reason="regex module not installed")
+def test_grep_repo_regex_still_works():
+    """A benign regex must still match when the regex module is available."""
+    graph = _repo_with_evil_line()
+    result = graph.grep_repo(r"function\s+\w+")
+    assert "withdraw" in result
+
+
+def test_grep_repo_overlong_pattern_is_capped():
+    """An absurdly long pattern must not blow up (length cap)."""
+    graph = _repo_with_evil_line()
+    result = graph.grep_repo("z" * 100_000)  # no match, but must return a string
+    assert isinstance(result, str)


### PR DESCRIPTION
## Problem (MEDIUM — DoS)

The agentic auditor gives the LLM a `grep_repo(pattern)` tool. The pattern is **attacker-influenceable** (prompt injection via contract comments), and it runs against contract source the attacker **also controls** (their own contract body, stored verbatim in the in-scope sources).

The old code:

```python
matcher = re.compile(needle, re.IGNORECASE)   # LLM-supplied pattern
...
matcher.search(text)                          # per line, no timeout
```

The stdlib `re` engine backtracks and **cannot be interrupted mid-match**. A catastrophic-backtracking pattern such as `(a+)+$` over a long `aaaa…a!` line (the attacker embeds both) pins a CPU core and hangs the single-threaded audit worker indefinitely. Existing guards don't help: `max_matches` / the 4000-char output cap never trigger (the hang is *inside* one `search()` call), and `re.error` is never raised (backtracking **hangs**, it doesn't raise).

Verified empirically: stdlib `re.search(r'(a+)+$', 'a'*35+'!')` had to be killed by a 4s process timeout.

## Fix

- Compile untrusted regexes **only** with the `regex` module, whose per-search `timeout=` bounds backtracking (verified: fires `TimeoutError` in 0.2s on a slow pattern).
- Cap pattern length (`_MAX_GREP_PATTERN_CHARS = 200`).
- On `TimeoutError`, drop the regex and substring-search the remainder.
- When `regex` is **not** installed, LLM patterns are never handed to stdlib `re` — substring search is used instead (ReDoS-free). `regex` is used opportunistically to keep core deps minimal (project's stated design); installing it enables full regex grep.

## Tests

New `tests/test_grep_repo_redos.py`: a `pytest.mark.timeout(10)` guard on the `(a+)+$` ReDoS pattern (hangs → test-killed under the old code; returns in <1s under the fix), plus substring/regex functionality and the length cap. 68 existing agentic tests still green. ruff + black clean.

Note: audit also confirmed `read_contract_source` is **safe** — it's a name-keyed dict lookup over pre-scanned in-scope sources, not a filesystem read, so path-traversal attempts (`../../etc/passwd`) are inert.