### PR TITLE
fix(mcp): correct runtime TypeError call-arg bugs in 4 MCP server tools

### DIFF
--- a/miesc/mcp_server.py
+++ b/miesc/mcp_server.py
@@ -427,14 +427,15 @@ async def miesc_correlate(
         return json.dumps({"error": "Invalid JSON input for findings_map"})
 
     try:
-        from miesc.core.correlation_api import SmartCorrelationEngine
+        from miesc.core.correlation_api import MIESCCorrelationAPI
 
-        engine = SmartCorrelationEngine()
-        correlated = engine.correlate(
-            findings_map,
-            min_confirmations=min_tools,
+        engine = MIESCCorrelationAPI(
+            min_tools_for_validation=min_tools,
             confidence_threshold=confidence_threshold,
         )
+        for tool_name, tool_findings in (findings_map or {}).items():
+            engine.add_tool_results(tool_name, tool_findings)
+        correlated = engine.analyze()
         return json.dumps(correlated, indent=2, default=str)
     except ImportError:
         return json.dumps(
@@ -461,7 +462,7 @@ async def miesc_filter_fp(findings_json: str, threshold: float = 0.50) -> str:
         from miesc.ml.false_positive_filter import FalsePositiveFilter
 
         fp_filter = FalsePositiveFilter()
-        filtered = fp_filter.filter_findings(findings, fp_threshold=threshold)
+        filtered = fp_filter.filter_findings(findings, threshold=threshold)
         return json.dumps(
             {
                 "original_count": len(findings) if isinstance(findings, list) else 0,
@@ -635,9 +636,35 @@ async def miesc_map_compliance(findings_json: str, frameworks: Optional[str] = N
         from miesc.security.compliance_mapper import ComplianceMapper
 
         mapper = ComplianceMapper()
-        framework_list = frameworks.split(",") if frameworks else None
-        mapping = mapper.map_findings(findings, frameworks=framework_list)
-        return json.dumps(mapping, indent=2, default=str)
+        # Optional framework filter: keep only the requested framework keys.
+        framework_keys = {
+            "iso27001": "iso27001_controls",
+            "nist": "nist_csf_functions",
+            "owasp": "owasp_sc_categories",
+            "cwe": "cwe_ids",
+            "swc": "swc_id",
+            "mitre": "mitre_techniques",
+        }
+        requested = (
+            {
+                framework_keys[f.strip().lower()]
+                for f in frameworks.split(",")
+                if f.strip().lower() in framework_keys
+            }
+            if frameworks
+            else None
+        )
+        result = []
+        for finding, mapping in mapper.map_findings(findings):
+            entry = mapping.to_dict()
+            if requested is not None:
+                entry = {
+                    k: v
+                    for k, v in entry.items()
+                    if k in requested or k in ("swc_title", "compliance_score")
+                }
+            result.append({"finding": finding, "compliance": entry})
+        return json.dumps(result, indent=2, default=str)
     except ImportError:
         return json.dumps({"error": "ComplianceMapper not available"})
 
@@ -658,8 +685,8 @@ async def miesc_remediate(findings_json: str, contract_name: str = "") -> str:
         from miesc.security.remediation_engine import RemediationEngine
 
         engine = RemediationEngine()
-        remediated = engine.enrich_findings(findings, contract_name=contract_name)
-        return json.dumps(remediated, indent=2, default=str)
+        remediated = engine.enrich_findings(findings)
+        return json.dumps([ef.to_dict() for ef in remediated], indent=2, default=str)
     except ImportError:
         # Fallback: basic remediation from finding data
         for f in (findings if isinstance(findings, list) else []):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,9 +30,13 @@ from miesc.mcp_server import (  # noqa: E402
     _summarize_results,
     _validate_contract_path,
     miesc_apply_fix,
+    miesc_correlate,
+    miesc_filter_fp,
     miesc_get_status,
     miesc_get_tool_info,
     miesc_list_tools,
+    miesc_map_compliance,
+    miesc_remediate,
     miesc_remediation_evidence_bundle,
     miesc_validate_remediation,
 )
@@ -265,3 +269,76 @@ contract Victim {
             )
         )
         assert data["status"] == "no_fixable_findings"
+
+
+# =========================================================================
+# Regression: runtime call-arg bugs in MCP tools
+#
+# These four tools shipped with wrong keyword arguments to their backing
+# engines. Because each tool only catches ImportError, a bad kwarg surfaced
+# as an *uncaught* TypeError ("unexpected keyword argument ...") at runtime.
+# The tests drive the REAL engines (no mocking) through the exact path that
+# previously raised, so they fail loudly if any call-arg regresses.
+# =========================================================================
+_REGRESSION_FINDING = {
+    "type": "reentrancy",
+    "severity": "High",
+    "title": "reentrancy",
+    "check": "reentrancy-eth",
+    "location": {"file": "C.sol", "line": 10, "function": "withdraw"},
+    "description": "external call before state update",
+}
+
+
+class TestMCPRuntimeBugRegressions:
+    def test_correlate_uses_correlation_api(self):
+        """miesc_correlate previously constructed the wrong SmartCorrelationEngine
+        with a confidence_threshold kwarg it did not accept."""
+        out = json.loads(
+            asyncio.run(
+                miesc_correlate(
+                    json.dumps({"slither": [_REGRESSION_FINDING]}),
+                    min_tools=2,
+                    confidence_threshold=0.5,
+                )
+            )
+        )
+        assert "error" not in out
+        # MIESCCorrelationAPI.analyze() returns the full correlation report.
+        assert {"metadata", "summary", "findings"} <= set(out)
+
+    def test_filter_fp_uses_threshold_kwarg(self):
+        """miesc_filter_fp passed fp_threshold=; the filter takes threshold=."""
+        out = json.loads(
+            asyncio.run(miesc_filter_fp(json.dumps([_REGRESSION_FINDING]), threshold=0.5))
+        )
+        assert "error" not in out
+        assert out["original_count"] == 1
+        assert "findings" in out
+
+    def test_map_compliance_no_frameworks_kwarg(self):
+        """map_findings takes no frameworks= param and returns (finding, mapping)
+        tuples; the tool must consume that shape, not a bare dict."""
+        out = json.loads(asyncio.run(miesc_map_compliance(json.dumps([_REGRESSION_FINDING]))))
+        assert isinstance(out, list) and len(out) == 1
+        assert "finding" in out[0] and "compliance" in out[0]
+        assert "swc_id" in out[0]["compliance"]
+
+    def test_map_compliance_framework_filter(self):
+        """The optional framework filter keeps only requested keys (+ metadata)."""
+        out = json.loads(
+            asyncio.run(
+                miesc_map_compliance(json.dumps([_REGRESSION_FINDING]), frameworks="swc,cwe")
+            )
+        )
+        keys = set(out[0]["compliance"])
+        assert {"swc_id", "cwe_ids"} <= keys
+        assert "iso27001_controls" not in keys and "nist_csf_functions" not in keys
+
+    def test_remediate_no_contract_name_kwarg(self):
+        """enrich_findings takes no contract_name= param and returns EnrichedFinding
+        objects; the tool must serialize them via to_dict()."""
+        out = json.loads(asyncio.run(miesc_remediate(json.dumps([_REGRESSION_FINDING]))))
+        assert isinstance(out, list) and len(out) == 1
+        # to_dict() shape, not the raw fallback dict.
+        assert "type" in out[0]


### PR DESCRIPTION
## What

Four `@mcp.tool()` endpoints in `miesc/mcp_server.py` called their backing engines with keyword arguments those engines never accepted. Each tool only catches `ImportError`, so the bad kwargs surfaced as **uncaught `TypeError`s at call time** — the tool would 500 the moment an MCP client invoked it with real input.

| Tool | Bug | Fix |
|------|-----|-----|
| `miesc_correlate` | Built the wrong `SmartCorrelationEngine` (two classes share the name; the resolved one lacks `confidence_threshold`) | Use `MIESCCorrelationAPI` → `add_tool_results()` + `analyze()` |
| `miesc_filter_fp` | `filter_findings(..., fp_threshold=)` | `threshold=` (the real param) |
| `miesc_map_compliance` | `map_findings(..., frameworks=)` (unsupported) and treated the `(finding, mapping)` tuples as a dict | Consume tuples, serialize via `to_dict()`, optional **client-side** framework filter |
| `miesc_remediate` | `enrich_findings(..., contract_name=)` (unsupported) and JSON-dumped `EnrichedFinding` objects raw | Drop the kwarg, serialize via `to_dict()` |

## Why it shipped

`mypy` is advisory in CI (`continue-on-error`), so these `call-arg` errors never blocked a merge. Surfaced during the repo quality/standards audit.

## Verification

- `mypy miesc/mcp_server.py` → **0 `call-arg` errors** (was 4).
- New `TestMCPRuntimeBugRegressions` drives the **real** engines (no mocking) through the exact previously-raising paths, incl. the framework-filter branch.
- `tests/test_mcp_server.py`: 26 passed. Full suite: **9552 passed, 1 skipped**.
- `ruff` + `black` clean. Paper freeze untouched (source/test only).