### PR TITLE
fix(security): refuse to deserialize group/world-writable ML models

### DIFF
--- a/miesc/ml/fp_ml_classifier.py
+++ b/miesc/ml/fp_ml_classifier.py
@@ -53,6 +53,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from miesc.security.safe_deserialize import safe_to_deserialize
+
 logger = logging.getLogger(__name__)
 
 
@@ -208,6 +210,11 @@ class AuditorTrainedFPClassifier:
     def _load_model(self) -> None:
         """Load a pre-trained model if available."""
         if not self.model_path.exists():
+            return
+        # pickle.load executes arbitrary code; refuse a model file another user
+        # could have tampered with (group/world-writable). Fail safe to None.
+        if not safe_to_deserialize(self.model_path):
+            self.model = None
             return
         try:
             with open(self.model_path, "rb") as f:

--- a/miesc/ml/triage_ranker.py
+++ b/miesc/ml/triage_ranker.py
@@ -21,6 +21,8 @@ import os
 import re
 from typing import Any, Callable, Optional
 
+from miesc.security.safe_deserialize import safe_to_deserialize
+
 DEFAULT_MODEL_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
     "models",
@@ -127,6 +129,11 @@ class TriageRanker:
 
     def _load(self) -> None:
         if not os.path.exists(self.model_path):
+            return
+        # joblib.load executes arbitrary code; refuse a model file another user
+        # could have tampered with (group/world-writable). Fail safe to None.
+        if not safe_to_deserialize(self.model_path):
+            self.model = None
             return
         try:
             import joblib

--- a/miesc/security/safe_deserialize.py
+++ b/miesc/security/safe_deserialize.py
@@ -1,0 +1,56 @@
+"""Guard against deserializing model files another user could have tampered with.
+
+``pickle.load`` / ``joblib.load`` execute arbitrary code during deserialization.
+MIESC's ML models (the FP classifier, the triage ranker) are trained locally and
+written to fixed paths, so the file is normally the user's own trusted artifact.
+But if that file is writable by *other* users — a shared/multi-user host, a
+world-writable cache directory, a poisoned image layer — another party could
+replace it with a code-executing payload that runs the next time a scan loads it.
+
+Following the principle SSH applies to private keys, refuse to deserialize a
+model file that is writable by group or others. The check is POSIX-based and a
+no-op where mode bits are not exposed; callers fail safe (model stays ``None``,
+degrading to the rule-based path) rather than raising.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+PathLike = Union[str, Path]
+
+
+def is_group_or_world_writable(path: PathLike) -> bool:
+    """Return True if ``path`` is writable by group or others (POSIX mode bits).
+
+    Returns False when the path is missing or the platform/filesystem does not
+    expose POSIX permission bits, where the check is not meaningful.
+    """
+    try:
+        mode = os.stat(path).st_mode
+    except OSError:
+        return False
+    return bool(mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
+def safe_to_deserialize(path: PathLike) -> bool:
+    """True if ``path`` is safe to pickle/joblib-load (not writable by others).
+
+    Logs a warning and returns False when the file is group/world-writable,
+    since another user could have replaced it with a malicious payload.
+    """
+    if is_group_or_world_writable(path):
+        logger.warning(
+            "Refusing to deserialize %s: file is writable by group/other; another "
+            "user could replace it with a code-executing payload. Fix: chmod go-w %s",
+            path,
+            path,
+        )
+        return False
+    return True

--- a/tests/test_safe_deserialize.py
+++ b/tests/test_safe_deserialize.py
@@ -1,0 +1,92 @@
+"""Tests for the model-deserialization guard.
+
+pickle.load / joblib.load execute arbitrary code. MIESC refuses to deserialize a
+model file that is writable by group or others (another user could have replaced
+it with a malicious payload), following the principle SSH uses for private keys.
+"""
+
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+
+from miesc.ml.fp_ml_classifier import AuditorTrainedFPClassifier
+from miesc.ml.triage_ranker import TriageRanker
+from miesc.security.safe_deserialize import (
+    is_group_or_world_writable,
+    safe_to_deserialize,
+)
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX permission bits not meaningful on Windows"
+)
+
+
+def _write_model(path: Path, mode: int, obj=None) -> Path:
+    path.write_bytes(pickle.dumps(obj if obj is not None else {"is_dummy": True}))
+    os.chmod(path, mode)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Helper unit tests
+# --------------------------------------------------------------------------- #
+
+
+@posix_only
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        (0o600, False),
+        (0o644, False),
+        (0o664, True),  # group-writable
+        (0o666, True),  # group + world writable
+        (0o602, True),  # world-writable
+    ],
+)
+def test_is_group_or_world_writable(tmp_path, mode, expected):
+    f = _write_model(tmp_path / "m.pkl", mode)
+    assert is_group_or_world_writable(f) is expected
+
+
+def test_is_group_or_world_writable_missing_path(tmp_path):
+    assert is_group_or_world_writable(tmp_path / "nope.pkl") is False
+
+
+@posix_only
+def test_safe_to_deserialize(tmp_path):
+    safe = _write_model(tmp_path / "safe.pkl", 0o600)
+    unsafe = _write_model(tmp_path / "unsafe.pkl", 0o666)
+    assert safe_to_deserialize(safe) is True
+    assert safe_to_deserialize(unsafe) is False
+
+
+# --------------------------------------------------------------------------- #
+# Loader integration
+# --------------------------------------------------------------------------- #
+
+
+@posix_only
+def test_fp_classifier_refuses_group_writable_model(tmp_path):
+    """A group/world-writable model must NOT be deserialized."""
+    model = _write_model(tmp_path / "fp.pkl", 0o666)
+    clf = AuditorTrainedFPClassifier(model_path=model)
+    assert clf.model is None
+
+
+@posix_only
+def test_fp_classifier_loads_owner_only_model(tmp_path):
+    """A 0600 model is trusted and loads normally (no false refusal)."""
+    model = _write_model(tmp_path / "fp.pkl", 0o600, obj={"is_dummy": True})
+    clf = AuditorTrainedFPClassifier(model_path=model)
+    assert clf.model == {"is_dummy": True}
+
+
+@posix_only
+def test_triage_ranker_refuses_group_writable_model(tmp_path):
+    """The refusal happens before joblib is even imported, so no joblib needed."""
+    model = _write_model(tmp_path / "triage.joblib", 0o664)
+    ranker = TriageRanker(model_path=str(model))
+    assert ranker.model is None


### PR DESCRIPTION
## Context

Found via an adversarial audit of the RAG subsystem. **The RAG retrieval path itself is clean** (SHA-256 cache keys, ChromaDB + static in-code KB, defensive parsing, no pickle/np.load). The one real deserialization exposure is in the adjacent ML model loaders:

- `miesc/ml/fp_ml_classifier.py` — `pickle.load` of `~/.miesc/models/fp_auditor_classifier.pkl`
- `miesc/ml/triage_ranker.py` — `joblib.load` of `triage_model.joblib`

`pickle.load`/`joblib.load` **execute arbitrary code** during deserialization, with no integrity check. These models are trained locally at fixed paths, so the file is normally the user's own trusted artifact — the scanned contract cannot reach these loads, so this is **not** a contract-triggerable RCE (severity LOW–MEDIUM). But the gap becomes real on a **shared/multi-user host**, a **world-writable cache dir**, or a **poisoned image layer**, where another user could replace the model with a code-executing payload that runs on the next scan.

## Fix

New `miesc/security/safe_deserialize.safe_to_deserialize(path)`: refuse to load a model file that is **writable by group or others**, following the principle SSH applies to private keys. Both loaders gate on it and **fail safe** (`model = None` → the existing rule-based / no-ranking degraded path), never raising.

- Owner-only (`0600`) and standard (`0644`) files load normally — **no false refusal**.
- Only group/world-**writable** files (`0664`/`0666`/`0602`/…) are refused.
- POSIX-based; a no-op where mode bits aren't exposed.

## Tests

New `tests/test_safe_deserialize.py` (10 cases, POSIX-guarded): the writable-check helper across modes, and per-loader integration — a group/world-writable model is refused (`model is None`) while a `0600` model with valid content loads. 55 existing fp-classifier / triage-ranker / security-regression tests still green. ruff + black clean.